### PR TITLE
ci: added basic ci

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs
+
+on:
+  push:
+    branches: [ master, 'dev/*' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Install APT dependencies
+      run: |
+        sudo apt-get install -y git build-essential apt-utils wget libfreetype6 libpng-dev libopenblas-dev gcc gfortran libsnappy-dev
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install -r requirements-docs.txt
+        pip install .
+    - name: Build docs
+      run: |
+        cd doc && make html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  push:
+    branches: [ master, 'dev/*' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: ${{ matrix.os }}, py-${{ matrix.python_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macOS-latest]
+        python_version: [3.6]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Install swig
+      if: "startsWith(runner.os, 'windows')"
+      run: |
+        (New-Object System.Net.WebClient).DownloadFile("http://prdownloads.sourceforge.net/swig/swigwin-4.0.1.zip","swigwin-4.0.1.zip");
+        Expand-Archive .\swigwin-4.0.1.zip .;
+        echo "$((Get-Item .).FullName)/swigwin-4.0.1" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Install APT dependencies
+      if: "startsWith(runner.os, 'ubuntu')"
+      run: |
+        sudo apt-get install -y git build-essential apt-utils wget libfreetype6 libpng-dev libopenblas-dev gcc gfortran libsnappy-dev
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install . -r requirements.txt
+    #- name: Typecheck
+    #  run: |
+    #    mypy --ignore-missing-imports
+    #- name: Test
+    #  run: |
+    #    poetry run pytest  # no tests, yet

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__
+
+# Built as part of docs
+doc/auto_examples
+doc/_build
+
+# Built by auto_examples
+examples/visual_cueing/*.csv


### PR DESCRIPTION
Split the CI part out of #22 for a faster merge since the poetry stuff was too big a change, also made the CI run on multiple platforms.

After a fair bit of battling the Windows build requiring `swig.exe`, it now runs well on Linux, macOS, and Windows. See a run here: https://github.com/ErikBjare/eeg-notebooks/actions/runs/368000950