### PR TITLE
ci: removed installation unnecessary apt dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,6 @@ jobs:
         (New-Object System.Net.WebClient).DownloadFile("http://prdownloads.sourceforge.net/swig/swigwin-4.0.1.zip","swigwin-4.0.1.zip");
         Expand-Archive .\swigwin-4.0.1.zip .;
         echo "$((Get-Item .).FullName)/swigwin-4.0.1" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Install APT dependencies
-      if: "startsWith(runner.os, 'ubuntu')"
-      run: |
-        sudo apt-get install -y git build-essential apt-utils wget libfreetype6 libpng-dev libopenblas-dev gcc gfortran libsnappy-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
-.. image:: https://mybinder.org/badge_logo.svg
+|badge_test| |badge_binder|
+
+.. |badge_test| image:: https://github.com/NeuroTechX/eeg-notebooks/workflows/Test/badge.svg
+   :target: https://github.com/NeuroTechX/eeg-notebooks/actions
+
+.. |badge_binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/NeuroTechX/eeg-notebooks/master
-      
 
 ===================================================================
 EEG-Notebooks - Democratizing the cognitive neuroscience experiment


### PR DESCRIPTION
Turns out the step didn't run (the `startsWith(os.runner, 'ubuntu')` should have been `startsWith(os.runner, 'linux')`), but since things work fine without it we might as well drop it altogether.

Edit: I also added a CI badge to the README.