### PR TITLE
style: formatted with `black eegnb/`

### DIFF
--- a/eegnb/__init__.py
+++ b/eegnb/__init__.py
@@ -1,24 +1,29 @@
 from os import path, makedirs
 from time import strftime, gmtime
 
-DATA_DIR = path.join(path.expanduser('~/'),'.eegnb', 'data')
+DATA_DIR = path.join(path.expanduser("~/"), ".eegnb", "data")
 
 
 def generate_save_fn(board_name, experiment, subject_id, session_nb, data_dir=DATA_DIR):
-    '''Generates a file name with the proper trial number for the current subject/experiment combo'''
+    """Generates a file name with the proper trial number for the current subject/experiment combo"""
 
     # convert subject ID to 4-digit number
-    subject_str = 'subject%04.f' % subject_id
-    session_str = 'session%03.f' % session_nb
+    subject_str = "subject%04.f" % subject_id
+    session_str = "session%03.f" % session_nb
 
     # folder structure is /DATA_DIR/experiment/site/subject/session/*.csv
-    recording_dir = path.join(data_dir, experiment, 'local', board_name, subject_str, session_str)
+    recording_dir = path.join(
+        data_dir, experiment, "local", board_name, subject_str, session_str
+    )
 
     # check if directory exists, if not, make the directory
     if not path.exists(recording_dir):
         makedirs(recording_dir)
 
     # generate filename based on recording date-and-timestamp and then append to recording_dir
-    save_fp = path.join(recording_dir, ("recording_%s" % strftime("%Y-%m-%d-%H.%M.%S", gmtime()) + ".csv"))
+    save_fp = path.join(
+        recording_dir,
+        ("recording_%s" % strftime("%Y-%m-%d-%H.%M.%S", gmtime()) + ".csv"),
+    )
 
     return save_fp

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -16,12 +16,13 @@ from eegnb import DATA_DIR
 from eegnb.devices.utils import EEG_INDICES, SAMPLE_FREQS
 
 
-sns.set_context('talk')
-sns.set_style('white')
+sns.set_context("talk")
+sns.set_style("white")
 
 
-def load_csv_as_raw(fnames, sfreq, ch_ind, aux_ind=None,
-                    replace_ch_names=None, verbose=1):
+def load_csv_as_raw(
+    fnames, sfreq, ch_ind, aux_ind=None, replace_ch_names=None, verbose=1
+):
     """Load CSV files into an MNE Raw object.
 
     Args:
@@ -55,32 +56,41 @@ def load_csv_as_raw(fnames, sfreq, ch_ind, aux_ind=None,
         data = pd.read_csv(fn)
 
         # Channel names and types
-        ch_names = [list(data.columns)[i] for i in ch_ind] + ['stim']
+        ch_names = [list(data.columns)[i] for i in ch_ind] + ["stim"]
         print(ch_names)
-        ch_types = ['eeg'] * n_eeg + ['misc'] * n_aux + ['stim']
+        ch_types = ["eeg"] * n_eeg + ["misc"] * n_aux + ["stim"]
 
         if replace_ch_names is not None:
-            ch_names = [c if c not in replace_ch_names.keys()
-                        else replace_ch_names[c] for c in ch_names]
+            ch_names = [
+                c if c not in replace_ch_names.keys() else replace_ch_names[c]
+                for c in ch_names
+            ]
 
         # Transpose EEG data and convert from uV to Volts
         data = data.values[:, ch_ind + [-1]].T
         data[:-1] *= 1e-6
 
         # create MNE object
-        info = create_info(ch_names=ch_names, ch_types=ch_types, sfreq=sfreq,
-                           verbose=1)
+        info = create_info(ch_names=ch_names, ch_types=ch_types, sfreq=sfreq, verbose=1)
         raw.append(RawArray(data=data, info=info, verbose=verbose))
 
     raws = concatenate_raws(raw, verbose=verbose)
-    montage = make_standard_montage('standard_1005')
+    montage = make_standard_montage("standard_1005")
     raws.set_montage(montage)
 
     return raws
 
 
-def load_data(subject_id, session_nb, device_name, experiment,
-              replace_ch_names=None, verbose=1, site='local', data_dir=None):
+def load_data(
+    subject_id,
+    session_nb,
+    device_name,
+    experiment,
+    replace_ch_names=None,
+    verbose=1,
+    site="local",
+    data_dir=None,
+):
     """Load CSV files from the /data directory into a Raw object.
 
     This is a utility function that simplifies access to eeg-notebooks
@@ -115,36 +125,37 @@ def load_data(subject_id, session_nb, device_name, experiment,
         (mne.io.RawArray): loaded EEG
     """
 
-    if subject_id == 'all':
-        subject_str = 'subject*'
+    if subject_id == "all":
+        subject_str = "subject*"
     else:
-        subject_str = 'subject%04.f' % subject_id
+        subject_str = "subject%04.f" % subject_id
 
-    if session_nb == 'all':
-        session_str = 'session*'
+    if session_nb == "all":
+        session_str = "session*"
     else:
-        session_str = 'session%03.f' % session_nb
+        session_str = "session%03.f" % session_nb
 
-    if site == 'all':
-        site = '*'
+    if site == "all":
+        site = "*"
 
     if data_dir is None:
-      data_dir = DATA_DIR
+        data_dir = DATA_DIR
 
-    data_path = os.path.join(data_dir, experiment, site, device_name,
-                             subject_str, session_str, '*.csv')
+    data_path = os.path.join(
+        data_dir, experiment, site, device_name, subject_str, session_str, "*.csv"
+    )
     fnames = glob(data_path)
 
     sfreq = SAMPLE_FREQS[device_name]
     ch_ind = EEG_INDICES[device_name]
-    if device_name in ['muse2016', 'muse2', 'museS']:
+    if device_name in ["muse2016", "muse2", "museS"]:
         return load_csv_as_raw(
             fnames,
             sfreq=sfreq,
             ch_ind=ch_ind,
             aux_ind=[5],
             replace_ch_names=replace_ch_names,
-            verbose=verbose
+            verbose=verbose,
         )
     else:
         return load_csv_as_raw(
@@ -152,13 +163,21 @@ def load_data(subject_id, session_nb, device_name, experiment,
             sfreq=sfreq,
             ch_ind=ch_ind,
             replace_ch_names=replace_ch_names,
-            verbose=verbose
+            verbose=verbose,
         )
 
 
-def plot_conditions(epochs, conditions=OrderedDict(), ci=97.5, n_boot=1000,
-                    title='', palette=None, ylim=(-6, 6),
-                    diff_waveform=(1, 2), channel_count=4):
+def plot_conditions(
+    epochs,
+    conditions=OrderedDict(),
+    ci=97.5,
+    n_boot=1000,
+    title="",
+    palette=None,
+    ylim=(-6, 6),
+    diff_waveform=(1, 2),
+    channel_count=4,
+):
     """Plot ERP conditions.
     Args:
         epochs (mne.epochs): EEG epochs
@@ -192,9 +211,8 @@ def plot_conditions(epochs, conditions=OrderedDict(), ci=97.5, n_boot=1000,
     times = epochs.times
     y = pd.Series(epochs.events[:, -1])
 
-    midaxis = math.ceil(channel_count/2)
-    fig, axes = plt.subplots(2, midaxis, figsize=[12, 6],
-                             sharex=True, sharey=True)
+    midaxis = math.ceil(channel_count / 2)
+    fig, axes = plt.subplots(2, midaxis, figsize=[12, 6], sharex=True, sharey=True)
 
     # get individual plot axis
     plot_axes = []
@@ -205,31 +223,41 @@ def plot_conditions(epochs, conditions=OrderedDict(), ci=97.5, n_boot=1000,
 
     for ch in range(channel_count):
         for cond, color in zip(conditions.values(), palette):
-            sns.tsplot(X[y.isin(cond), ch], time=times, color=color,
-                       n_boot=n_boot, ci=ci, ax=axes[ch])
+            sns.tsplot(
+                X[y.isin(cond), ch],
+                time=times,
+                color=color,
+                n_boot=n_boot,
+                ci=ci,
+                ax=axes[ch],
+            )
 
         if diff_waveform:
-            diff = (np.nanmean(X[y == diff_waveform[1], ch], axis=0) -
-                    np.nanmean(X[y == diff_waveform[0], ch], axis=0))
-            axes[ch].plot(times, diff, color='k', lw=1)
+            diff = np.nanmean(X[y == diff_waveform[1], ch], axis=0) - np.nanmean(
+                X[y == diff_waveform[0], ch], axis=0
+            )
+            axes[ch].plot(times, diff, color="k", lw=1)
 
         axes[ch].set_title(epochs.ch_names[ch])
         axes[ch].set_ylim(ylim)
-        axes[ch].axvline(x=0, ymin=ylim[0], ymax=ylim[1], color='k',
-                         lw=1, label='_nolegend_')
+        axes[ch].axvline(
+            x=0, ymin=ylim[0], ymax=ylim[1], color="k", lw=1, label="_nolegend_"
+        )
 
-    axes[0].set_xlabel('Time (s)')
-    axes[0].set_ylabel('Amplitude (uV)')
-    axes[-1].set_xlabel('Time (s)')
-    axes[1].set_ylabel('Amplitude (uV)')
+    axes[0].set_xlabel("Time (s)")
+    axes[0].set_ylabel("Amplitude (uV)")
+    axes[-1].set_xlabel("Time (s)")
+    axes[1].set_ylabel("Amplitude (uV)")
 
     if diff_waveform:
-        legend = (['{} - {}'.format(diff_waveform[1], diff_waveform[0])] +
-                  list(conditions.keys()))
+        legend = ["{} - {}".format(diff_waveform[1], diff_waveform[0])] + list(
+            conditions.keys()
+        )
     else:
         legend = conditions.keys()
-    axes[-1].legend(legend, bbox_to_anchor=(1.05, 1), loc='upper left',
-                    borderaxespad=0.)
+    axes[-1].legend(
+        legend, bbox_to_anchor=(1.05, 1), loc="upper left", borderaxespad=0.0
+    )
     sns.despine()
     plt.tight_layout()
 
@@ -239,8 +267,9 @@ def plot_conditions(epochs, conditions=OrderedDict(), ci=97.5, n_boot=1000,
     return fig, axes
 
 
-def plot_highlight_regions(x, y, hue, hue_thresh=0, xlabel='', ylabel='',
-                           legend_str=()):
+def plot_highlight_regions(
+    x, y, hue, hue_thresh=0, xlabel="", ylabel="", legend_str=()
+):
     """Plot a line with highlighted regions based on additional value.
     Plot a line and highlight ranges of x for which an additional value
     is lower than a threshold. For example, the additional value might be
@@ -262,7 +291,7 @@ def plot_highlight_regions(x, y, hue, hue_thresh=0, xlabel='', ylabel='',
     """
     fig, axes = plt.subplots(1, 1, figsize=(10, 5), sharey=True)
 
-    axes.plot(x, y, lw=2, c='k')
+    axes.plot(x, y, lw=2, c="k")
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
 
@@ -283,7 +312,7 @@ def plot_highlight_regions(x, y, hue, hue_thresh=0, xlabel='', ylabel='',
 
     st = (x[1] - x[0]) / 2.0
     for p in a:
-        axes.axvspan(x[p[0]]-st, x[p[1]]+st, facecolor='g', alpha=0.5)
+        axes.axvspan(x[p[0]] - st, x[p[1]] + st, facecolor="g", alpha=0.5)
     plt.legend(legend_str)
     sns.despine()
 

--- a/eegnb/analysis/utils_old.py
+++ b/eegnb/analysis/utils_old.py
@@ -13,12 +13,18 @@ import seaborn as sns
 from matplotlib import pyplot as plt
 
 
-sns.set_context('talk')
-sns.set_style('white')
+sns.set_context("talk")
+sns.set_style("white")
 
 
-def load_muse_csv_as_raw(filename, sfreq=256., ch_ind=[0, 1, 2, 3],
-                         stim_ind=5, replace_ch_names=None, verbose=1):
+def load_muse_csv_as_raw(
+    filename,
+    sfreq=256.0,
+    ch_ind=[0, 1, 2, 3],
+    stim_ind=5,
+    replace_ch_names=None,
+    verbose=1,
+):
     """Load CSV files into a Raw object.
 
     Args:
@@ -48,15 +54,17 @@ def load_muse_csv_as_raw(filename, sfreq=256., ch_ind=[0, 1, 2, 3],
         data = pd.read_csv(fname, index_col=0)
 
         # name of each channels
-        ch_names = list(data.columns)[0:n_channel] + ['Stim']
+        ch_names = list(data.columns)[0:n_channel] + ["Stim"]
 
         if replace_ch_names is not None:
-            ch_names = [c if c not in replace_ch_names.keys()
-                        else replace_ch_names[c] for c in ch_names]
+            ch_names = [
+                c if c not in replace_ch_names.keys() else replace_ch_names[c]
+                for c in ch_names
+            ]
 
         # type of each channels
-        ch_types = ['eeg'] * n_channel + ['stim']
-        montage = make_standard_montage('standard_1005')
+        ch_types = ["eeg"] * n_channel + ["stim"]
+        montage = make_standard_montage("standard_1005")
 
         # get data and exclude Aux channel
         data = data.values[:, ch_ind + [stim_ind]].T
@@ -65,21 +73,36 @@ def load_muse_csv_as_raw(filename, sfreq=256., ch_ind=[0, 1, 2, 3],
         data[:-1] *= 1e-6
 
         # create MNE object
-        info = create_info(ch_names=ch_names, ch_types=ch_types,
-                           sfreq=sfreq, montage=montage, verbose=verbose)
+        info = create_info(
+            ch_names=ch_names,
+            ch_types=ch_types,
+            sfreq=sfreq,
+            montage=montage,
+            verbose=verbose,
+        )
         raw.append(RawArray(data=data, info=info, verbose=verbose))
 
     # concatenate all raw objects
-    print('raw is')
+    print("raw is")
     print(raw)
     raws = concatenate_raws(raw, verbose=verbose)
 
     return raws
 
 
-def load_data(data_dir,site='eegnb_examples', experiment='visual_n170',
-              device='muse2016', subject_nb=1, session_nb=1,sfreq=256.,
-              ch_ind=[0, 1, 2, 3], stim_ind=5, replace_ch_names=None, verbose=1):
+def load_data(
+    data_dir,
+    site="eegnb_examples",
+    experiment="visual_n170",
+    device="muse2016",
+    subject_nb=1,
+    session_nb=1,
+    sfreq=256.0,
+    ch_ind=[0, 1, 2, 3],
+    stim_ind=5,
+    replace_ch_names=None,
+    verbose=1,
+):
 
     """Load CSV files from the /data directory into a Raw object.
 
@@ -101,25 +124,37 @@ def load_data(data_dir,site='eegnb_examples', experiment='visual_n170',
     Returns:
         (mne.io.array.array.RawArray): loaded EEG
     """
-    if subject_nb == 'all':
-        subject_nb = '*'
-    if session_nb == 'all':
-        session_nb = '*'
+    if subject_nb == "all":
+        subject_nb = "*"
+    if session_nb == "all":
+        session_nb = "*"
 
-    subject_nb_str = '%04.f' %subject_nb
-    session_nb_str = '%03.f' %session_nb
-    subsess = 'subject{}/session{}/*.csv'.format(subject_nb_str, session_nb_str)
+    subject_nb_str = "%04.f" % subject_nb
+    session_nb_str = "%03.f" % session_nb
+    subsess = "subject{}/session{}/*.csv".format(subject_nb_str, session_nb_str)
     data_path = os.path.join(data_dir, experiment, site, device, subsess)
     fnames = glob(data_path)
 
-    return load_muse_csv_as_raw(fnames, sfreq=sfreq, ch_ind=ch_ind,
-                                stim_ind=stim_ind,
-                                replace_ch_names=replace_ch_names, verbose=verbose)
+    return load_muse_csv_as_raw(
+        fnames,
+        sfreq=sfreq,
+        ch_ind=ch_ind,
+        stim_ind=stim_ind,
+        replace_ch_names=replace_ch_names,
+        verbose=verbose,
+    )
 
 
-def plot_conditions(epochs, conditions=OrderedDict(), ci=97.5, n_boot=1000,
-                    title='', palette=None, ylim=(-6, 6),
-                    diff_waveform=(1, 2)):
+def plot_conditions(
+    epochs,
+    conditions=OrderedDict(),
+    ci=97.5,
+    n_boot=1000,
+    title="",
+    palette=None,
+    ylim=(-6, 6),
+    diff_waveform=(1, 2),
+):
     """Plot ERP conditions.
 
     Args:
@@ -156,36 +191,44 @@ def plot_conditions(epochs, conditions=OrderedDict(), ci=97.5, n_boot=1000,
     times = epochs.times
     y = pd.Series(epochs.events[:, -1])
 
-    fig, axes = plt.subplots(2, 2, figsize=[12, 6],
-                             sharex=True, sharey=True)
+    fig, axes = plt.subplots(2, 2, figsize=[12, 6], sharex=True, sharey=True)
     axes = [axes[1, 0], axes[0, 0], axes[0, 1], axes[1, 1]]
 
     for ch in range(4):
         for cond, color in zip(conditions.values(), palette):
-            sns.tsplot(X[y.isin(cond), ch], time=times, color=color,
-                       n_boot=n_boot, ci=ci, ax=axes[ch])
+            sns.tsplot(
+                X[y.isin(cond), ch],
+                time=times,
+                color=color,
+                n_boot=n_boot,
+                ci=ci,
+                ax=axes[ch],
+            )
 
         if diff_waveform:
-            diff = (np.nanmean(X[y == diff_waveform[1], ch], axis=0) -
-                    np.nanmean(X[y == diff_waveform[0], ch], axis=0))
-            axes[ch].plot(times, diff, color='k', lw=1)
+            diff = np.nanmean(X[y == diff_waveform[1], ch], axis=0) - np.nanmean(
+                X[y == diff_waveform[0], ch], axis=0
+            )
+            axes[ch].plot(times, diff, color="k", lw=1)
 
         axes[ch].set_title(epochs.ch_names[ch])
         axes[ch].set_ylim(ylim)
-        axes[ch].axvline(x=0, ymin=ylim[0], ymax=ylim[1], color='k',
-                         lw=1, label='_nolegend_')
+        axes[ch].axvline(
+            x=0, ymin=ylim[0], ymax=ylim[1], color="k", lw=1, label="_nolegend_"
+        )
 
-    axes[0].set_xlabel('Time (s)')
-    axes[0].set_ylabel('Amplitude (uV)')
-    axes[-1].set_xlabel('Time (s)')
-    axes[1].set_ylabel('Amplitude (uV)')
+    axes[0].set_xlabel("Time (s)")
+    axes[0].set_ylabel("Amplitude (uV)")
+    axes[-1].set_xlabel("Time (s)")
+    axes[1].set_ylabel("Amplitude (uV)")
 
     if diff_waveform:
-        legend = (['{} - {}'.format(diff_waveform[1], diff_waveform[0])] +
-                  list(conditions.keys()))
+        legend = ["{} - {}".format(diff_waveform[1], diff_waveform[0])] + list(
+            conditions.keys()
+        )
     else:
         legend = conditions.keys()
-    axes[-1].legend(legend,loc='lower right')
+    axes[-1].legend(legend, loc="lower right")
     sns.despine()
     plt.tight_layout()
 
@@ -195,8 +238,9 @@ def plot_conditions(epochs, conditions=OrderedDict(), ci=97.5, n_boot=1000,
     return fig, axes
 
 
-def plot_highlight_regions(x, y, hue, hue_thresh=0, xlabel='', ylabel='',
-                           legend_str=()):
+def plot_highlight_regions(
+    x, y, hue, hue_thresh=0, xlabel="", ylabel="", legend_str=()
+):
     """Plot a line with highlighted regions based on additional value.
 
     Plot a line and highlight ranges of x for which an additional value
@@ -222,7 +266,7 @@ def plot_highlight_regions(x, y, hue, hue_thresh=0, xlabel='', ylabel='',
     """
     fig, axes = plt.subplots(1, 1, figsize=(10, 5), sharey=True)
 
-    axes.plot(x, y, lw=2, c='k')
+    axes.plot(x, y, lw=2, c="k")
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
 
@@ -243,7 +287,7 @@ def plot_highlight_regions(x, y, hue, hue_thresh=0, xlabel='', ylabel='',
 
     st = (x[1] - x[0]) / 2.0
     for p in a:
-        axes.axvspan(x[p[0]]-st, x[p[1]]+st, facecolor='g', alpha=0.5)
+        axes.axvspan(x[p[0]] - st, x[p[1]] + st, facecolor="g", alpha=0.5)
     plt.legend(legend_str)
     sns.despine()
 

--- a/eegnb/cli/__main__.py
+++ b/eegnb/cli/__main__.py
@@ -6,7 +6,7 @@ from .cli import CLI
 def main():
     parser = argparse.ArgumentParser(
         description="eeg-notebooks command line interface",
-        usage='''eegnb <command> [<args>]
+        usage="""eegnb <command> [<args>]
 
     Available commands:
     ===================
@@ -57,21 +57,22 @@ def main():
 
 
 
-    ''')
+    """,
+    )
 
-    parser.add_argument('command', help='Command to run.')
+    parser.add_argument("command", help="Command to run.")
 
     # parse_args defaults to [1:] for args, but you need to
     # exclude the rest of the args too, or validation will fail
     args = parser.parse_args(sys.argv[1:2])
 
     if not hasattr(CLI, args.command):
-        print('Incorrect usage. See help below.')
+        print("Incorrect usage. See help below.")
         parser.print_help()
         exit(1)
 
     cli = CLI(args.command)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/cli/cli.py
+++ b/eegnb/cli/cli.py
@@ -2,60 +2,90 @@
 import sys
 import argparse
 
-class CLI:
 
+class CLI:
     def __init__(self, command):
         # use dispatch pattern to invoke method with same name
         getattr(self, command)()
 
-
     def runexp(self):
 
-        parser = argparse.ArgumentParser(description='Run EEG experiment.')
-   
-        parser.add_argument('-ed','--eegdevice', dest='eeg_device', type=str, 
-                            default=None, help='add help here')
+        parser = argparse.ArgumentParser(description="Run EEG experiment.")
 
-        parser.add_argument('-ma', '--macaddr', dest='mac_address', type=str,
-                            default=False,help='add help here')
+        parser.add_argument(
+            "-ed",
+            "--eegdevice",
+            dest="eeg_device",
+            type=str,
+            default=None,
+            help="add help here",
+        )
 
-        parser.add_argument('-ex', '--expt', dest='experiment', type=str,
-                            default=None, help='add help str')
+        parser.add_argument(
+            "-ma",
+            "--macaddr",
+            dest="mac_address",
+            type=str,
+            default=False,
+            help="add help here",
+        )
 
-        parser.add_argument('-rd', '--recdur', dest='record_duration', type=str,
-                            default=None, help='add help str')
+        parser.add_argument(
+            "-ex",
+            "--expt",
+            dest="experiment",
+            type=str,
+            default=None,
+            help="add help str",
+        )
 
-        parser.add_argument('-of', '--outfname', dest='save_fn', type=str,
-                            default=None, help='add help str')
+        parser.add_argument(
+            "-rd",
+            "--recdur",
+            dest="record_duration",
+            type=str,
+            default=None,
+            help="add help str",
+        )
 
-        parser.add_argument('-ip', '--inprom', dest='inprompt', action='store_true',
-                            help='add help str')
-        
+        parser.add_argument(
+            "-of",
+            "--outfname",
+            dest="save_fn",
+            type=str,
+            default=None,
+            help="add help str",
+        )
+
+        parser.add_argument(
+            "-ip", "--inprom", dest="inprompt", action="store_true", help="add help str"
+        )
+
         args = parser.parse_args(sys.argv[2:])
-       
+
         if args.inprompt:
-            print('run command line prompt script')
+            print("run command line prompt script")
             from .introprompt import main as run_introprompt
+
             run_introprompt()
         else:
             from .utils import run_experiment
             from eegnb.devices.eeg import EEG
 
-            if args.eeg_device == 'ganglion':
-              # if the ganglion is chosen a MAC address should also be proviced
-              eeg_device = EEG(device=args.eeg_device, mac_addr=args.mac_address)
+            if args.eeg_device == "ganglion":
+                # if the ganglion is chosen a MAC address should also be proviced
+                eeg_device = EEG(device=args.eeg_device, mac_addr=args.mac_address)
             else:
-              eeg_device = EEG(device=args.eeg_device)
+                eeg_device = EEG(device=args.eeg_device)
 
-            run_experiment(args.experiment, args.record_duration, 
-                           eeg_device, args.save_fn)
-
-
+            run_experiment(
+                args.experiment, args.record_duration, eeg_device, args.save_fn
+            )
 
     def view(self):
-        print('add viewer functionality here')
-        
-        #args = parser.parse_args(sys.argv[2:])
-        #from . import view
-        #view(args.window, args.scale, args.refresh,
+        print("add viewer functionality here")
+
+        # args = parser.parse_args(sys.argv[2:])
+        # from . import view
+        # view(args.window, args.scale, args.refresh,
         #     args.figure, args.version, args.backend)

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -6,76 +6,111 @@ from .utils import run_experiment
 
 
 def intro_prompt():
-    """ This function handles the user prompts for inputting information about the session they wish to record.
-
-    """
+    """This function handles the user prompts for inputting information about the session they wish to record."""
     # define the names of the available boards
     boards = [
-        'None', 'Muse2016', 'Muse2', 'MuseS', 'OpenBCI Ganglion', 'OpenBCI Cyton',
-        'OpenBCI Cyton + Daisy', 'G.Tec Unicorn', 'BrainBit', 'Notion 1', 'Notion 2', 'Synthetic'
+        "None",
+        "Muse2016",
+        "Muse2",
+        "MuseS",
+        "OpenBCI Ganglion",
+        "OpenBCI Cyton",
+        "OpenBCI Cyton + Daisy",
+        "G.Tec Unicorn",
+        "BrainBit",
+        "Notion 1",
+        "Notion 2",
+        "Synthetic",
     ]
 
     # also define the board codes for passing to functions
     board_codes = [
-        'none', 'muse2016', 'muse2', 'museS',
-        'ganglion', 'cyton', 'cyton_daisy',
-        'unicorn', 'brainbit', 'notion1', 'notion2', 'synthetic'
+        "none",
+        "muse2016",
+        "muse2",
+        "museS",
+        "ganglion",
+        "cyton",
+        "cyton_daisy",
+        "unicorn",
+        "brainbit",
+        "notion1",
+        "notion2",
+        "synthetic",
     ]
 
-    experiments = ['visual-N170', 'visual-P300', 'visual-SSVEP', 'auditory-oddball', 'auditory-SSAEP']
+    experiments = [
+        "visual-N170",
+        "visual-P300",
+        "visual-SSVEP",
+        "auditory-oddball",
+        "auditory-SSAEP",
+    ]
 
     # have the user input which device they intend to record with
-    print("Welcome to NeurotechX EEG Notebooks. \n"
-          "Please enter the integer value corresponding to your EEG device: \n"
-          f"[0] {boards[0]} \n"
-          f"[1] {boards[1]} \n"
-          f"[2] {boards[2]} \n"
-          f"[3] {boards[3]} \n"
-          f"[4] {boards[4]} \n"
-          f"[5] {boards[5]} \n"
-          f"[6] {boards[6]} \n"
-          f"[7] {boards[7]} \n"
-          f"[8] {boards[8]} \n"
-          f"[9] {boards[9]} \n"
-          f"[10] {boards[10]} \n",
-          f"[11] {boards[11]} \n")
+    print(
+        "Welcome to NeurotechX EEG Notebooks. \n"
+        "Please enter the integer value corresponding to your EEG device: \n"
+        f"[0] {boards[0]} \n"
+        f"[1] {boards[1]} \n"
+        f"[2] {boards[2]} \n"
+        f"[3] {boards[3]} \n"
+        f"[4] {boards[4]} \n"
+        f"[5] {boards[5]} \n"
+        f"[6] {boards[6]} \n"
+        f"[7] {boards[7]} \n"
+        f"[8] {boards[8]} \n"
+        f"[9] {boards[9]} \n"
+        f"[10] {boards[10]} \n",
+        f"[11] {boards[11]} \n",
+    )
 
-    board_idx = int(input('Enter Board Selection: '))
-    board_selection = board_codes[board_idx]    # Board_codes are the actual names to be passed to the EEG class
+    board_idx = int(input("Enter Board Selection: "))
+    board_selection = board_codes[
+        board_idx
+    ]  # Board_codes are the actual names to be passed to the EEG class
     print(f"Selected board {boards[board_idx]} \n")
 
     # Handles connectivity selection if an OpenBCI board is being used
-    if board_selection in ['cyton', 'cyton_daisy', 'ganglion']:
+    if board_selection in ["cyton", "cyton_daisy", "ganglion"]:
 
         # determine whether board is connected via Wifi or BLE
-        print("Please select your connection method:\n"
-              "[0] usb dongle \n"
-              "[1] wifi shield \n")
+        print(
+            "Please select your connection method:\n"
+            "[0] usb dongle \n"
+            "[1] wifi shield \n"
+        )
         connect_idx = int(input("Enter connection method: "))
 
         # add "_wifi" suffix to the end of the board name for brainflow
         if connect_idx == 1:
             board_selection = board_selection + "_wifi"
 
-        if board_selection == 'ganglion':
+        if board_selection == "ganglion":
             # If the Ganglion is being used, you can enter optional Ganglion mac address
-            ganglion_mac_address = input("\nGanglion MAC Address (Press Enter to Autoscan): ")    
-        elif board_selection == 'ganglion_wifi':
+            ganglion_mac_address = input(
+                "\nGanglion MAC Address (Press Enter to Autoscan): "
+            )
+        elif board_selection == "ganglion_wifi":
             # IP address is required for this board configuration
             ip_address = input("\nEnter Ganglion+WiFi IP Address: ")
-        elif board_selection == 'cyton_wifi' or board_selection == 'cyton_daisy_wifi':
-            print(f"\n{boards[board_idx]} + WiFi is not supported. Please use the dongle that was shipped with the device.\n")
+        elif board_selection == "cyton_wifi" or board_selection == "cyton_daisy_wifi":
+            print(
+                f"\n{boards[board_idx]} + WiFi is not supported. Please use the dongle that was shipped with the device.\n"
+            )
             exit()
 
     # Experiment selection
-    print("\nPlease select which experiment you would like to run: \n"
-          "[0] visual n170 \n"
-          "[1] visual p300 \n"
-          "[2] ssvep \n"
-          "[3] auditory_oddball \n"
-          "[4] auditory_ssaep \n")
+    print(
+        "\nPlease select which experiment you would like to run: \n"
+        "[0] visual n170 \n"
+        "[1] visual p300 \n"
+        "[2] ssvep \n"
+        "[3] auditory_oddball \n"
+        "[4] auditory_ssaep \n"
+    )
 
-    exp_idx = int(input('Enter Experiment Selection: '))
+    exp_idx = int(input("Enter Experiment Selection: "))
     exp_selection = experiments[exp_idx]
     print(f"Selected experiment {exp_selection} \n")
 
@@ -92,10 +127,10 @@ def intro_prompt():
     session_nb = int(input("Enter session #: "))
 
     # start the EEG device
-    if board_selection.startswith('ganglion'):
-        if board_selection == 'ganglion_wifi':
+    if board_selection.startswith("ganglion"):
+        if board_selection == "ganglion_wifi":
             eeg_device = EEG(device=board_selection, ip_addr=ip_address)
-        else: 
+        else:
             eeg_device = EEG(device=board_selection, mac_addr=ganglion_mac_address)
     else:
         eeg_device = EEG(device=board_selection)
@@ -117,7 +152,5 @@ def main():
     run_experiment(experiment, record_duration, eeg_device, save_fn)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()
-
-

--- a/eegnb/cli/utils.py
+++ b/eegnb/cli/utils.py
@@ -1,4 +1,3 @@
-
 from eegnb.experiments.visual_n170 import n170
 from eegnb.experiments.visual_p300 import p300
 from eegnb.experiments.visual_ssvep import ssvep
@@ -12,12 +11,15 @@ import numpy as np, pandas as pd
 
 
 import eegnb
+
 eegnb_dir = os.path.dirname(eegnb.__file__)
-mcond_file = os.path.join(eegnb_dir, 'experiments', 'auditory_oddball', 'MUSE_conditions.mat')
+mcond_file = os.path.join(
+    eegnb_dir, "experiments", "auditory_oddball", "MUSE_conditions.mat"
+)
 
 
 def makeoddball(inputs, rep):
-    #based on inputs, creating oddball paradigms markers depending on "switch"
+    # based on inputs, creating oddball paradigms markers depending on "switch"
     value = inputs[0]
     count = 0
     markerArray = []
@@ -31,62 +33,75 @@ def makeoddball(inputs, rep):
         else:
             if count == rep + 1:
                 markerArray.append(2)
-            
+
             else:
                 markerArray.append(4)
             value = inputs[i]
             count = 1
     return markerArray
 
+
 def maketonesnums(num):
     newArray = []
     for i in range(num):
-        newArray.append(90000+i)
-    return newArray   
-      
+        newArray.append(90000 + i)
+    return newArray
+
 
 def run_experiment(experiment, record_duration, eeg_device, save_fn):
-    if experiment == 'visual-N170':
+    if experiment == "visual-N170":
         n170.present(duration=record_duration, eeg=eeg_device, save_fn=save_fn)
-    elif experiment == 'visual-P300':
+    elif experiment == "visual-P300":
         p300.present(duration=record_duration, eeg=eeg_device, save_fn=save_fn)
-    elif experiment == 'visual-SSVEP':
+    elif experiment == "visual-SSVEP":
         ssvep.present(duration=record_duration, eeg=eeg_device, save_fn=save_fn)
-    elif experiment == 'auditory-SSAEP':
+    elif experiment == "auditory-SSAEP":
         ssaep.present(duration=record_duration, eeg=eeg_device, save_fn=save_fn)
-    elif experiment == 'auditory-oddball':
-        #conditions_file = os.path.join(eegnb_file, 'experiments', 'auditory-oddball', "MUSE_conditions.mat")
-        F = h5py.File(mcond_file, 'r')#['museEEG']
-        highPE = np.squeeze(F['museEEG']['design']['highPE'][:]).astype(int)
-        lowPE = np.squeeze(F['museEEG']['design']['lowPE'][:]).astype(int)
-        inputs = np.squeeze(F['museEEG']['design']['inputs'][:]).astype(int)
+    elif experiment == "auditory-oddball":
+        # conditions_file = os.path.join(eegnb_file, 'experiments', 'auditory-oddball', "MUSE_conditions.mat")
+        F = h5py.File(mcond_file, "r")  # ['museEEG']
+        highPE = np.squeeze(F["museEEG"]["design"]["highPE"][:]).astype(int)
+        lowPE = np.squeeze(F["museEEG"]["design"]["lowPE"][:]).astype(int)
+        inputs = np.squeeze(F["museEEG"]["design"]["inputs"][:]).astype(int)
 
-        #based on inputs, creating oddball paradigms markers depending on "switch"
+        # based on inputs, creating oddball paradigms markers depending on "switch"
         tonenums = maketonesnums(1800)
         oddball3 = makeoddball(inputs, 3)
         oddball4 = makeoddball(inputs, 4)
         oddball5 = makeoddball(inputs, 5)
         oddball6 = makeoddball(inputs, 6)
 
-        #modifying 0s in PE definitions of tones that represent markers to 3s to avoid loss of trials instead of ignoring them
+        # modifying 0s in PE definitions of tones that represent markers to 3s to avoid loss of trials instead of ignoring them
         for i in range(len(highPE)):
             if highPE[i] == 0:
                 highPE[i] = 3
             if lowPE[i] == 0:
-                lowPE[i] = 3  
-           
-        #1 is standard/bottom, 2 is deviant/high, 3 is "baseline trial"
+                lowPE[i] = 3
+
+        # 1 is standard/bottom, 2 is deviant/high, 3 is "baseline trial"
 
         stim_types = inputs
-        itis = np.ones_like(inputs)*0.5 
+        itis = np.ones_like(inputs) * 0.5
 
-        newAdditionalMarkers = [];
+        newAdditionalMarkers = []
 
         for i in range(0, len(highPE)):
-            newAdditionalMarker = str(oddball3[i]) + str(oddball4[i]) + str(oddball5[i]) + str(oddball6[i]) + str(highPE[i]) + str(lowPE[i])
+            newAdditionalMarker = (
+                str(oddball3[i])
+                + str(oddball4[i])
+                + str(oddball5[i])
+                + str(oddball6[i])
+                + str(highPE[i])
+                + str(lowPE[i])
+            )
             newAdditionalMarkers.append(newAdditionalMarker)
 
-        additional_labels = {'labels' : newAdditionalMarkers}
-        aMMN.present(record_duration=record_duration,stim_types=stim_types,itis=itis, additional_labels = {'labels' : newAdditionalMarkers}, eeg=eeg_device, save_fn=save_fn)
-        
-
+        additional_labels = {"labels": newAdditionalMarkers}
+        aMMN.present(
+            record_duration=record_duration,
+            stim_types=stim_types,
+            itis=itis,
+            additional_labels={"labels": newAdditionalMarkers},
+            eeg=eeg_device,
+            save_fn=save_fn,
+        )

--- a/eegnb/datasets/__init__.py
+++ b/eegnb/datasets/__init__.py
@@ -1,3 +1,1 @@
-
 from .datasets import fetch_dataset
-

--- a/eegnb/datasets/datasets.py
+++ b/eegnb/datasets/datasets.py
@@ -7,43 +7,60 @@ import gdown
 from eegnb import DATA_DIR
 
 
-def fetch_dataset(data_dir=None, experiment=None, site='eegnb_examples',
-                  device='muse2016', subjects='all', sessions='all',
-                  download_method = 'gdown'):
+def fetch_dataset(
+    data_dir=None,
+    experiment=None,
+    site="eegnb_examples",
+    device="muse2016",
+    subjects="all",
+    sessions="all",
+    download_method="gdown",
+):
     """
-            Return a long-form filenames list and a table saying what
-            subject and session, and run each entry corresponds to
+    Return a long-form filenames list and a table saying what
+    subject and session, and run each entry corresponds to
 
-            Usage:
-                    data_dir = '/my_folder'
-                    experiment = 'visual-N170'
-                    subjects = [1]
-                    sessions = 'all'
+    Usage:
+            data_dir = '/my_folder'
+            experiment = 'visual-N170'
+            subjects = [1]
+            sessions = 'all'
 
-                    visn170_fnames = fetch_dataset(data_dir=data_dir, subjects='all', experiment='visual-N170',
-                    site='eegnb_examples')
+            visn170_fnames = fetch_dataset(data_dir=data_dir, subjects='all', experiment='visual-N170',
+            site='eegnb_examples')
 
-                    visnP300_fnames = fetch_dataset(data_dir=data_dir, subjects=[1], experiment='visual-P300',
-                    site='eegnb_examples')
+            visnP300_fnames = fetch_dataset(data_dir=data_dir, subjects=[1], experiment='visual-P300',
+            site='eegnb_examples')
 
 
 
     """
     # List of experiments available
-    experiments_list = ['rest', 'auditory-P300', 'auditory-SSAEP', 'visual-cueing',
-                          'visual-gonogo','visual-leftright','visual-N170',
-                          'visual-P300','visual-spatialfreq', 'visual-SSVEP']
+    experiments_list = [
+        "rest",
+        "auditory-P300",
+        "auditory-SSAEP",
+        "visual-cueing",
+        "visual-gonogo",
+        "visual-leftright",
+        "visual-N170",
+        "visual-P300",
+        "visual-spatialfreq",
+        "visual-SSVEP",
+    ]
 
     # List gdrive extensions for various experiments
-    gdrive_locs = {'visual-SSVEP':'1zj9Wx-YEMJo7GugUUu7Sshcybfsr-Fze',
-                    'visual-spatialfreq':'1ggBt7CNvMgddxji-FvxcZoP-IF-PmESX',
-                    'visual-P300':'1OLcj-zSjqdNrsBSUAsGBXOwWDnGWTVFC',
-                    'visual-N170': '1oStfxzEqf36R5d-2Auyw4DLnPj9E_FAH',
-                    'visual-leftright': '1f8A4Vbz0xjfgGIYFldMZ7ZL02x7T0jSt',
-                    'visual-nogono': '1C8WKg9TXyp8A3QJ6T8zbGnk6jFcMutad',
-                    'visual-cueing': '1ABOVJ9S0BeJOsqdGFnexaTFZ-ZcsIXfQ',
-                    'auditory-SSAEP': '1fd0OAyNGWWOHD8e1FnEOLeQMeEoxqEpO',
-                    'auditory-P300': '1OEtrRfMOkzDssGv-2Lj56FsArmPnQ2vD'}
+    gdrive_locs = {
+        "visual-SSVEP": "1zj9Wx-YEMJo7GugUUu7Sshcybfsr-Fze",
+        "visual-spatialfreq": "1ggBt7CNvMgddxji-FvxcZoP-IF-PmESX",
+        "visual-P300": "1OLcj-zSjqdNrsBSUAsGBXOwWDnGWTVFC",
+        "visual-N170": "1oStfxzEqf36R5d-2Auyw4DLnPj9E_FAH",
+        "visual-leftright": "1f8A4Vbz0xjfgGIYFldMZ7ZL02x7T0jSt",
+        "visual-nogono": "1C8WKg9TXyp8A3QJ6T8zbGnk6jFcMutad",
+        "visual-cueing": "1ABOVJ9S0BeJOsqdGFnexaTFZ-ZcsIXfQ",
+        "auditory-SSAEP": "1fd0OAyNGWWOHD8e1FnEOLeQMeEoxqEpO",
+        "auditory-P300": "1OEtrRfMOkzDssGv-2Lj56FsArmPnQ2vD",
+    }
 
     # If no non-default top-level data path specified, use default
     if data_dir == None:
@@ -51,7 +68,7 @@ def fetch_dataset(data_dir=None, experiment=None, site='eegnb_examples',
 
     # check parameter entries
     if experiment not in experiments_list:
-        raise ValueError('experiment not in database')
+        raise ValueError("experiment not in database")
 
     # check if data has been previously downloaded
     download_it = False
@@ -64,72 +81,79 @@ def fetch_dataset(data_dir=None, experiment=None, site='eegnb_examples',
         if os.path.exists(data_dir) is not True:
             os.makedirs(data_dir)
 
-        destination = os.path.join(data_dir, 'downloaded_data.zip')
-        
-        if download_method == 'gdown':
+        destination = os.path.join(data_dir, "downloaded_data.zip")
 
-          URL = 'https://drive.google.com/uc?id=' + gdrive_locs[experiment]
-          gdown.download(URL, destination, quiet=False)
+        if download_method == "gdown":
 
+            URL = "https://drive.google.com/uc?id=" + gdrive_locs[experiment]
+            gdown.download(URL, destination, quiet=False)
 
-        elif download_method == 'requests':
+        elif download_method == "requests":
 
-          URL = "https://docs.google.com/uc?export=download"
+            URL = "https://docs.google.com/uc?export=download"
 
-          session = requests.Session()
-          response = session.get(URL, params = { 'id' : gdrive_locs[experiment] }, stream = True)
+            session = requests.Session()
+            response = session.get(
+                URL, params={"id": gdrive_locs[experiment]}, stream=True
+            )
 
-          # get the confirmation token to download large files
-          token = None
-          for key, value in response.cookies.items():
-              if key.startswith('download_warning'):
-                  token = value
+            # get the confirmation token to download large files
+            token = None
+            for key, value in response.cookies.items():
+                if key.startswith("download_warning"):
+                    token = value
 
-          if token:
-              params = {'id' : id, 'confirm' : token}
-              response = session.get(URL, params=params, stream=True)
+            if token:
+                params = {"id": id, "confirm": token}
+                response = session.get(URL, params=params, stream=True)
 
-          # save content to the zip-file
-          CHUNK_SIZE = 32768
-          with open(destination, "wb") as f:
-              for chunk in response.iter_content(CHUNK_SIZE):
-                  if chunk:
-                      f.write(chunk)
-
-
+            # save content to the zip-file
+            CHUNK_SIZE = 32768
+            with open(destination, "wb") as f:
+                for chunk in response.iter_content(CHUNK_SIZE):
+                    if chunk:
+                        f.write(chunk)
 
         # unzip the file
-        with zipfile.ZipFile(destination, 'r') as zip_ref:
+        with zipfile.ZipFile(destination, "r") as zip_ref:
             zip_ref.extractall(data_dir)
 
         # remove the compressed zip archive
         os.remove(destination)
 
-    if subjects == 'all': subjects = ['*']
-    if sessions == 'all':  sessions = ['*']
+    if subjects == "all":
+        subjects = ["*"]
+    if sessions == "all":
+        sessions = ["*"]
 
-    # If 'all' subjects and 'all sesssions: 
-    if ( (subjects[0] == '*') and (sessions[0] == '*') ): 
-      pth = os.path.join(exp_dir ,f'subject{subjects[0]}', f'session{sessions[0]}', '*.csv')
-      fnames = glob.glob(pth)
-    # Else, if specific subjects and sessions 
+    # If 'all' subjects and 'all sesssions:
+    if (subjects[0] == "*") and (sessions[0] == "*"):
+        pth = os.path.join(
+            exp_dir, f"subject{subjects[0]}", f"session{sessions[0]}", "*.csv"
+        )
+        fnames = glob.glob(pth)
+    # Else, if specific subjects and sessions
     else:
-      fnames = []
-      for subject_nb in subjects:
-          if subject_nb != '*':
-              # Format to get 4 digit number, e.g. 0004
-              subject_nb = float(subject_nb)
-              subject_nb = '%03.f' %subject_nb
-              for session_nb in sessions:
-                  # Formt to get 3 digit number, e.g. 003
-                  if session_nb != '*':
-                      session_nb = float(session_nb)
-                      session_nb = '%02.f' %session_nb
+        fnames = []
+        for subject_nb in subjects:
+            if subject_nb != "*":
+                # Format to get 4 digit number, e.g. 0004
+                subject_nb = float(subject_nb)
+                subject_nb = "%03.f" % subject_nb
+                for session_nb in sessions:
+                    # Formt to get 3 digit number, e.g. 003
+                    if session_nb != "*":
+                        session_nb = float(session_nb)
+                        session_nb = "%02.f" % session_nb
 
-                      pth = os.path.join(exp_dir, f'subject{subject_nb}', f'session{session_nb}', '*.csv')
-                      #pth = '{}/subject{}/session{}/*.csv'.format(exp_dir,subject_nb, session_nb)
-                      fpaths = glob.glob(pth)
-                      fnames += fpaths
+                        pth = os.path.join(
+                            exp_dir,
+                            f"subject{subject_nb}",
+                            f"session{session_nb}",
+                            "*.csv",
+                        )
+                        # pth = '{}/subject{}/session{}/*.csv'.format(exp_dir,subject_nb, session_nb)
+                        fpaths = glob.glob(pth)
+                        fnames += fpaths
 
     return fnames
-

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -22,18 +22,32 @@ from eegnb.devices.utils import get_openbci_usb, create_stim_array
 
 # list of brainflow devices
 brainflow_devices = [
-    'ganglion', 'ganglion_wifi',
-    'cyton', 'cyton_wifi',
-    'cyton_daisy', 'cyton_daisy_wifi',
-    'brainbit', 'unicorn', 'synthetic',
-    'brainbit', 'notion1', 'notion2'
+    "ganglion",
+    "ganglion_wifi",
+    "cyton",
+    "cyton_wifi",
+    "cyton_daisy",
+    "cyton_daisy_wifi",
+    "brainbit",
+    "unicorn",
+    "synthetic",
+    "brainbit",
+    "notion1",
+    "notion2",
 ]
 
 
 class EEG:
-
-    def __init__(self, device=None, serial_port=None, serial_num=None, mac_addr=None, other=None, ip_addr=None):
-        """ The initialization function takes the name of the EEG device and determines whether or not
+    def __init__(
+        self,
+        device=None,
+        serial_port=None,
+        serial_num=None,
+        mac_addr=None,
+        other=None,
+        ip_addr=None,
+    ):
+        """The initialization function takes the name of the EEG device and determines whether or not
         the device belongs to the Muse or Brainflow families and initializes the appropriate backend.
 
         Parameters:
@@ -50,16 +64,16 @@ class EEG:
         self.initialize_backend()
 
     def initialize_backend(self):
-        if self.backend == 'brainflow':
+        if self.backend == "brainflow":
             self._init_brainflow()
-        elif self.backend == 'muselsl':
+        elif self.backend == "muselsl":
             self._init_muselsl()
 
     def _get_backend(self, device_name):
-        if (device_name in brainflow_devices):
-            return 'brainflow'
-        elif device_name in ['muse2016', 'muse2', 'museS']:
-            return 'muselsl'
+        if device_name in brainflow_devices:
+            return "brainflow"
+        elif device_name in ["muse2016", "muse2", "museS"]:
+            return "muselsl"
 
     #####################
     #   MUSE functions  #
@@ -77,16 +91,20 @@ class EEG:
             # self.muse = muses[0]
 
             # Start streaming process
-            self.stream_process = Process(target=stream, args=(self.muses[0]['address'],))
+            self.stream_process = Process(
+                target=stream, args=(self.muses[0]["address"],)
+            )
             self.stream_process.start()
 
         # Create markers stream outlet
-        self.muse_StreamInfo = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+        self.muse_StreamInfo = StreamInfo(
+            "Markers", "Markers", 1, 0, "int32", "myuidw43536"
+        )
         self.muse_StreamOutlet = StreamOutlet(self.muse_StreamInfo)
 
         # Start a background process that will stream data from the first available Muse
         print("starting background recording process")
-        print('will save to file: %s' % self.save_fn)
+        print("will save to file: %s" % self.save_fn)
         self.recording = Process(target=record, args=(duration, self.save_fn))
         self.recording.start()
 
@@ -105,7 +123,7 @@ class EEG:
     #   BrainFlow functions  #
     ##########################
     def _init_brainflow(self):
-        """ This function initializes the brainflow backend based on the input device name. It calls
+        """This function initializes the brainflow backend based on the input device name. It calls
         a utility function to determine the appropriate USB port to use based on the current operating system.
         Additionally, the system allows for passing a serial number in the case that they want to use either
         the BraintBit or the Unicorn EEG devices from the brainflow family.
@@ -116,7 +134,7 @@ class EEG:
         # Initialize brainflow parameters
         self.brainflow_params = BrainFlowInputParams()
 
-        if self.device_name == 'ganglion':
+        if self.device_name == "ganglion":
             self.brainflow_id = BoardIds.GANGLION_BOARD.value
             if self.serial_port == None:
                 self.brainflow_params.serial_port = get_openbci_usb()
@@ -126,51 +144,51 @@ class EEG:
             else:
                 self.brainflow_params.mac_address = self.mac_address
 
-        elif self.device_name == 'ganglion_wifi':
+        elif self.device_name == "ganglion_wifi":
             self.brainflow_id = BoardIds.GANGLION_WIFI_BOARD.value
             if self.ip_addr is not None:
                 self.brainflow_params.ip_address = self.ip_addr
                 self.brainflow_params.ip_port = 6677
 
-        elif self.device_name == 'cyton':
+        elif self.device_name == "cyton":
             self.brainflow_id = BoardIds.CYTON_BOARD.value
             if self.serial_port is None:
                 self.brainflow_params.serial_port = get_openbci_usb()
 
-        elif self.device_name == 'cyton_wifi':
+        elif self.device_name == "cyton_wifi":
             self.brainflow_id = BoardIds.CYTON_WIFI_BOARD.value
             if self.ip_addr is not None:
                 self.brainflow_params.ip_address = self.ip_addr
                 self.brainflow_params.ip_port = 6677
 
-        elif self.device_name == 'cyton_daisy':
+        elif self.device_name == "cyton_daisy":
             self.brainflow_id = BoardIds.CYTON_DAISY_BOARD.value
             if self.serial_port is None:
                 self.brainflow_params.serial_port = get_openbci_usb()
 
-        elif self.device_name == 'cyton_daisy_wifi':
+        elif self.device_name == "cyton_daisy_wifi":
             self.brainflow_id = BoardIds.CYTON_DAISY_WIFI_BOARD.value
             if self.ip_addr is not None:
                 self.brainflow_params.ip_address = self.ip_addr
 
-        elif self.device_name == 'brainbit':
+        elif self.device_name == "brainbit":
             self.brainflow_id = BoardIds.BRAINBIT_BOARD.value
 
-        elif self.device_name == 'unicorn':
+        elif self.device_name == "unicorn":
             self.brainflow_id = BoardIds.UNICORN_BOARD.value
 
-        elif self.device_name == 'callibri_eeg':
+        elif self.device_name == "callibri_eeg":
             self.brainflow_id = BoardIds.CALLIBRI_EEG_BOARD.value
             if self.other:
                 self.brainflow_params.other_info = str(self.other)
 
-        elif self.device_name == 'notion1':
+        elif self.device_name == "notion1":
             self.brainflow_id = BoardIds.NOTION_1_BOARD.value
 
-        elif self.device_name == 'notion2':
+        elif self.device_name == "notion2":
             self.brainflow_id = BoardIds.NOTION_2_BOARD.value
 
-        elif self.device_name == 'synthetic':
+        elif self.device_name == "synthetic":
             self.brainflow_id = BoardIds.SYNTHETIC_BOARD.value
 
         # some devices allow for an optional serial number parameter for better connection
@@ -204,9 +222,12 @@ class EEG:
         data = data.T  # transpose data
 
         # get the channel names for EEG data
-        if self.brainflow_id == BoardIds.GANGLION_BOARD.value or self.brainflow_id == BoardIds.GANGLION_WIFI_BOARD.value:
+        if (
+            self.brainflow_id == BoardIds.GANGLION_BOARD.value
+            or self.brainflow_id == BoardIds.GANGLION_WIFI_BOARD.value
+        ):
             # if a ganglion is used, use recommended default EEG channel names
-            ch_names = ['fp1', 'fp2', 'tp7', 'tp8']
+            ch_names = ["fp1", "fp2", "tp7", "tp8"]
         else:
             # otherwise select eeg channel names via brainflow API
             ch_names = BoardShim.get_eeg_names(self.brainflow_id)
@@ -217,13 +238,17 @@ class EEG:
 
         # Create a column for the stimuli to append to the EEG data
         stim_array = create_stim_array(timestamps, self.markers)
-        timestamps = timestamps[..., None]  # Add an additional dimension so that shapes match
+        timestamps = timestamps[
+            ..., None
+        ]  # Add an additional dimension so that shapes match
         total_data = np.append(timestamps, eeg_data, 1)
-        total_data = np.append(total_data, stim_array, 1)  # Append the stim array to data.
+        total_data = np.append(
+            total_data, stim_array, 1
+        )  # Append the stim array to data.
 
         # Subtract five seconds of settling time from beginning
-        total_data = total_data[5 * self.sfreq:]
-        data_df = pd.DataFrame(total_data, columns=['timestamps'] + ch_names + ['stim'])
+        total_data = total_data[5 * self.sfreq :]
+        data_df = pd.DataFrame(total_data, columns=["timestamps"] + ch_names + ["stim"])
         data_df.to_csv(self.save_fn, index=False)
 
     def _brainflow_push_sample(self, marker):
@@ -231,7 +256,7 @@ class EEG:
         self.markers.append([marker, last_timestamp])
 
     def start(self, fn, duration=None):
-        """ Starts the EEG device based on the defined backend.
+        """Starts the EEG device based on the defined backend.
 
         Parameters:
             fn (str): name of the file to save the sessions data to.
@@ -239,27 +264,26 @@ class EEG:
         if fn:
             self.save_fn = fn
 
-        if self.backend == 'brainflow':  # Start brainflow backend
+        if self.backend == "brainflow":  # Start brainflow backend
             self._start_brainflow()
             self.markers = []
-        elif self.backend == 'muselsl':
+        elif self.backend == "muselsl":
             self._start_muse(duration)
 
     def push_sample(self, marker, timestamp):
-        """ Universal method for pushing a marker and its timestamp to store alongside the EEG data.
+        """Universal method for pushing a marker and its timestamp to store alongside the EEG data.
 
         Parameters:
             marker (int): marker number for the stimuli being presented.
             timestamp (float): timestamp of stimulus onset from time.time() function.
         """
-        if self.backend == 'brainflow':
+        if self.backend == "brainflow":
             self._brainflow_push_sample(marker=marker)
-        elif self.backend == 'muselsl':
+        elif self.backend == "muselsl":
             self._muse_push_sample(marker=marker, timestamp=timestamp)
 
     def stop(self):
-        if self.backend == 'brainflow':
+        if self.backend == "brainflow":
             self._stop_brainflow()
-        elif self.backend == 'muselsl':
+        elif self.backend == "muselsl":
             pass
-

--- a/eegnb/devices/utils.py
+++ b/eegnb/devices/utils.py
@@ -8,59 +8,60 @@ from brainflow import BoardShim, BoardIds
 
 # Default channel names for the various brainflow devices.
 EEG_CHANNELS = {
-    'ganglion': ['fp1', 'fp2', 'tp7', 'tp8'],
-    'cyton': BoardShim.get_eeg_names(BoardIds.CYTON_BOARD.value),
-    'cyton_daisy': BoardShim.get_eeg_names(BoardIds.CYTON_DAISY_BOARD.value),
-    'brainbit': BoardShim.get_eeg_names(BoardIds.BRAINBIT_BOARD.value),
-    'unicorn': BoardShim.get_eeg_names(BoardIds.UNICORN_BOARD.value),
-    'synthetic': BoardShim.get_eeg_names(BoardIds.SYNTHETIC_BOARD.value),
-    'notion1': BoardShim.get_eeg_names(BoardIds.NOTION_1_BOARD.value),
-    'notion2': BoardShim.get_eeg_names(BoardIds.NOTION_2_BOARD.value),
+    "ganglion": ["fp1", "fp2", "tp7", "tp8"],
+    "cyton": BoardShim.get_eeg_names(BoardIds.CYTON_BOARD.value),
+    "cyton_daisy": BoardShim.get_eeg_names(BoardIds.CYTON_DAISY_BOARD.value),
+    "brainbit": BoardShim.get_eeg_names(BoardIds.BRAINBIT_BOARD.value),
+    "unicorn": BoardShim.get_eeg_names(BoardIds.UNICORN_BOARD.value),
+    "synthetic": BoardShim.get_eeg_names(BoardIds.SYNTHETIC_BOARD.value),
+    "notion1": BoardShim.get_eeg_names(BoardIds.NOTION_1_BOARD.value),
+    "notion2": BoardShim.get_eeg_names(BoardIds.NOTION_2_BOARD.value),
 }
 
 BRAINFLOW_CHANNELS = {
-    'ganglion': [],
-    'cyton': EEG_CHANNELS['cyton'] + ['accel_0', 'accel_1', 'accel_2'],
-    'cyton_daisy': EEG_CHANNELS['cyton_daisy'] + ['accel_0', 'accel_1', 'accel_2'],
-    'synthetic': EEG_CHANNELS['synthetic'],
+    "ganglion": [],
+    "cyton": EEG_CHANNELS["cyton"] + ["accel_0", "accel_1", "accel_2"],
+    "cyton_daisy": EEG_CHANNELS["cyton_daisy"] + ["accel_0", "accel_1", "accel_2"],
+    "synthetic": EEG_CHANNELS["synthetic"],
 }
 
 EEG_INDICES = {
-    'muse2016': [1, 2, 3, 4],
-    'muse2': [1, 2, 3, 4],
-    'museS': [1,2,3,4],
-    'ganglion': BoardShim.get_eeg_channels(BoardIds.GANGLION_BOARD.value),
-    'cyton': BoardShim.get_eeg_channels(BoardIds.CYTON_BOARD.value),
-    'cyton_daisy': BoardShim.get_eeg_channels(BoardIds.CYTON_DAISY_BOARD.value),
-    'brainbit': BoardShim.get_eeg_channels(BoardIds.BRAINBIT_BOARD.value),
-    'unicorn': BoardShim.get_eeg_channels(BoardIds.UNICORN_BOARD.value),
-    'synthetic': BoardShim.get_eeg_channels(BoardIds.SYNTHETIC_BOARD.value),
-    'notion1': BoardShim.get_eeg_channels(BoardIds.NOTION_1_BOARD.value),
-    'notion2': BoardShim.get_eeg_channels(BoardIds.NOTION_2_BOARD.value),
+    "muse2016": [1, 2, 3, 4],
+    "muse2": [1, 2, 3, 4],
+    "museS": [1, 2, 3, 4],
+    "ganglion": BoardShim.get_eeg_channels(BoardIds.GANGLION_BOARD.value),
+    "cyton": BoardShim.get_eeg_channels(BoardIds.CYTON_BOARD.value),
+    "cyton_daisy": BoardShim.get_eeg_channels(BoardIds.CYTON_DAISY_BOARD.value),
+    "brainbit": BoardShim.get_eeg_channels(BoardIds.BRAINBIT_BOARD.value),
+    "unicorn": BoardShim.get_eeg_channels(BoardIds.UNICORN_BOARD.value),
+    "synthetic": BoardShim.get_eeg_channels(BoardIds.SYNTHETIC_BOARD.value),
+    "notion1": BoardShim.get_eeg_channels(BoardIds.NOTION_1_BOARD.value),
+    "notion2": BoardShim.get_eeg_channels(BoardIds.NOTION_2_BOARD.value),
 }
 
 SAMPLE_FREQS = {
-    'muse2016': 256,
-    'muse2': 256,
-    'museS': 256,
-    'ganglion': BoardShim.get_sampling_rate(BoardIds.GANGLION_BOARD.value),
-    'cyton': BoardShim.get_sampling_rate(BoardIds.CYTON_BOARD.value),
-    'cyton_daisy': BoardShim.get_sampling_rate(BoardIds.CYTON_DAISY_BOARD.value),
-    'brainbit': BoardShim.get_sampling_rate(BoardIds.BRAINBIT_BOARD.value),
-    'unicorn': BoardShim.get_sampling_rate(BoardIds.UNICORN_BOARD.value),
-    'synthetic': BoardShim.get_sampling_rate(BoardIds.SYNTHETIC_BOARD.value),
-    'notion1': BoardShim.get_sampling_rate(BoardIds.NOTION_1_BOARD.value),
-    'notion2': BoardShim.get_sampling_rate(BoardIds.NOTION_2_BOARD.value),
+    "muse2016": 256,
+    "muse2": 256,
+    "museS": 256,
+    "ganglion": BoardShim.get_sampling_rate(BoardIds.GANGLION_BOARD.value),
+    "cyton": BoardShim.get_sampling_rate(BoardIds.CYTON_BOARD.value),
+    "cyton_daisy": BoardShim.get_sampling_rate(BoardIds.CYTON_DAISY_BOARD.value),
+    "brainbit": BoardShim.get_sampling_rate(BoardIds.BRAINBIT_BOARD.value),
+    "unicorn": BoardShim.get_sampling_rate(BoardIds.UNICORN_BOARD.value),
+    "synthetic": BoardShim.get_sampling_rate(BoardIds.SYNTHETIC_BOARD.value),
+    "notion1": BoardShim.get_sampling_rate(BoardIds.NOTION_1_BOARD.value),
+    "notion2": BoardShim.get_sampling_rate(BoardIds.NOTION_2_BOARD.value),
 }
 
+
 def create_stim_array(timestamps, markers):
-    """ Creates a stim array which is the lenmgth of the EEG data where the stimuli are lined up
+    """Creates a stim array which is the lenmgth of the EEG data where the stimuli are lined up
     with their corresponding EEG sample.
 
     Parameters:
         timestamps (array of floats): Timestamps from the EEG data.
         markers (array of ints): Markers and their associated timestamps.
-        """
+    """
     num_samples = len(timestamps)
     stim_array = np.zeros((num_samples, 1))
     for marker in markers:
@@ -69,18 +70,20 @@ def create_stim_array(timestamps, markers):
 
     return stim_array
 
+
 def get_openbci_usb():
-    print('\nGetting a list of available serial ports...')
+    print("\nGetting a list of available serial ports...")
     port_list = serial_ports()
     i = 0
     for port in port_list:
-        print(f'[{i}] {port}')
+        print(f"[{i}] {port}")
         i += 1
-    port_number = input('Select Port(number): ')
-    if port_number == '':
-        return port_list[int(input('This field is required. Select Port(number): '))]
+    port_number = input("Select Port(number): ")
+    if port_number == "":
+        return port_list[int(input("This field is required. Select Port(number): "))]
     else:
-        return str(port_list[int(port_number)]).split(' - ')[0]
+        return str(port_list[int(port_number)]).split(" - ")[0]
+
 
 def serial_ports():
     return serial.tools.list_ports.comports()

--- a/eegnb/experiments/auditory_oddball/aMMN.py
+++ b/eegnb/experiments/auditory_oddball/aMMN.py
@@ -11,32 +11,41 @@ from psychopy import visual, core, event, sound
 from eegnb import generate_save_fn
 
 
-def present(record_duration=120,stim_types=None,itis=None,additional_labels={},secs=0.07,volume=0.8, eeg=None, save_fn=None):
-   
+def present(
+    record_duration=120,
+    stim_types=None,
+    itis=None,
+    additional_labels={},
+    secs=0.07,
+    volume=0.8,
+    eeg=None,
+    save_fn=None,
+):
+
     markernames = [1, 2]
     record_duration = np.float32(record_duration)
-    
+
     ## Initialize stimuli
-    #aud1 = sound.Sound('C', octave=5, sampleRate=44100, secs=secs)
-    aud1 = sound.Sound(440,secs=secs)#, octave=5, sampleRate=44100, secs=secs)
+    # aud1 = sound.Sound('C', octave=5, sampleRate=44100, secs=secs)
+    aud1 = sound.Sound(440, secs=secs)  # , octave=5, sampleRate=44100, secs=secs)
     aud1.setVolume(volume)
-    
-    #aud2 = sound.Sound('D', octave=6, sampleRate=44100, secs=secs)
-    aud2 = sound.Sound(528,secs=secs)
+
+    # aud2 = sound.Sound('D', octave=6, sampleRate=44100, secs=secs)
+    aud2 = sound.Sound(528, secs=secs)
     aud2.setVolume(volume)
     auds = [aud1, aud2]
-    
+
     # Setup trial list
-    trials = DataFrame(dict(sound_ind=stim_types,iti=itis))
-    
-    for col_name,col_vec in additional_labels.items():
+    trials = DataFrame(dict(sound_ind=stim_types, iti=itis))
+
+    for col_name, col_vec in additional_labels.items():
         trials[col_name] = col_vec
 
     # Setup graphics
-    mywin = visual.Window([1920, 1080], monitor='testMonitor', units='deg',
-                          fullscr=True)
-    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0,
-                                  rgb=[1, 0, 0])
+    mywin = visual.Window(
+        [1920, 1080], monitor="testMonitor", units="deg", fullscr=True
+    )
+    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0, rgb=[1, 0, 0])
     fixation.setAutoDraw(True)
     mywin.flip()
     iteratorthing = 0
@@ -44,41 +53,40 @@ def present(record_duration=120,stim_types=None,itis=None,additional_labels={},s
     # start the EEG stream, will delay 5 seconds to let signal settle
     if eeg:
         if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
-            save_fn = generate_save_fn(eeg.device_name, 'auditoryaMMN', 'unnamed')
-            print(f'No path for a save file was passed to the experiment. Saving data to {save_fn}')
-        eeg.start(save_fn,duration=record_duration)
-        
+            save_fn = generate_save_fn(eeg.device_name, "auditoryaMMN", "unnamed")
+            print(
+                f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
+            )
+        eeg.start(save_fn, duration=record_duration)
+
     show_instructions(10)
-    
+
     # Start EEG Stream, wait for signal to settle, and then pull timestamp for start point
     start = time()
 
     # Iterate through the events
     for ii, trial in trials.iterrows():
-        
+
         iteratorthing = iteratorthing + 1
-        
+
         # Inter trial interval
-        core.wait(trial['iti'])
+        core.wait(trial["iti"])
 
         # Select and display image
-        ind = int(trial['sound_ind'])
-        auds[ind].stop()        
+        ind = int(trial["sound_ind"])
+        auds[ind].stop()
         auds[ind].play()
 
         # Push sample
-        if eeg: 
+        if eeg:
             timestamp = time()
-            if eeg.backend == 'muselsl':
-                marker = [additional_labels['labels'][iteratorthing - 1]]
-                marker = list(map(int, marker)) 
+            if eeg.backend == "muselsl":
+                marker = [additional_labels["labels"][iteratorthing - 1]]
+                marker = list(map(int, marker))
             else:
-                marker = additional_labels['labels'][iteratorthing - 1]
+                marker = additional_labels["labels"][iteratorthing - 1]
             eeg.push_sample(marker=marker, timestamp=timestamp)
-    
 
-
-        
         mywin.flip()
         if len(event.getKeys()) > 0:
             break
@@ -86,20 +94,20 @@ def present(record_duration=120,stim_types=None,itis=None,additional_labels={},s
             break
 
         event.clearEvents()
-        
+
         if iteratorthing == 1798:
             sleep(10)
-            
 
     # Cleanup
-    if eeg: eeg.stop()
+    if eeg:
+        eeg.stop()
 
     mywin.close()
-    
+
+
 def show_instructions(duration):
 
-    instruction_text = \
-    """
+    instruction_text = """
     Welcome to the aMMN experiment! 
  
     Stay still, focus on the centre of the screen, and try not to blink. 
@@ -109,19 +117,15 @@ def show_instructions(duration):
     Press spacebar to continue. 
     
     """
-    instruction_text = instruction_text %duration
+    instruction_text = instruction_text % duration
 
     # graphics
-    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg",
-                          fullscr=True)
+    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
 
     mywin.mouseVisible = False
 
-    #Instructions
-    text = visual.TextStim(
-        win=mywin,
-        text=instruction_text,
-        color=[-1, -1, -1])
+    # Instructions
+    text = visual.TextStim(win=mywin, text=instruction_text, color=[-1, -1, -1])
     text.draw()
     mywin.flip()
     event.waitKeys(keyList="space")

--- a/eegnb/experiments/auditory_oddball/auditory_erp_arrayin.py
+++ b/eegnb/experiments/auditory_oddball/auditory_erp_arrayin.py
@@ -9,101 +9,105 @@ from psychopy import visual, core, event, sound
 from pylsl import StreamInfo, StreamOutlet
 
 
-def present(duration=120,stim_types=None,itis=None,additional_labels={},secs=0.07,volume=0.8):
-            
-    # additional_labels is dict with column names as keys and column vecs as values, 
-    # that will be added to the dataframe
-    
-    
-    #def present(duration=120, n_trials=10, iti=0.3, soa=0.2, jitter=0.2, 
-    #            secs=0.2, volume=0.8, random_state=None):
-    
-    
-    # Create markers stream outlet
-    #info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
-    #info = StreamInfo('Markers', 'Markers', 1 + len(additional_labels), 0, 'int32', 'myuidw43536')
-    info = StreamInfo('Markers', 'Markers', 1 + len(additional_labels), 0, 'float32', 'myuidw43536')
- 
-    outlet = StreamOutlet(info)    
+def present(
+    duration=120,
+    stim_types=None,
+    itis=None,
+    additional_labels={},
+    secs=0.07,
+    volume=0.8,
+):
 
-    #np.random.seed(random_state)
+    # additional_labels is dict with column names as keys and column vecs as values,
+    # that will be added to the dataframe
+
+    # def present(duration=120, n_trials=10, iti=0.3, soa=0.2, jitter=0.2,
+    #            secs=0.2, volume=0.8, random_state=None):
+
+    # Create markers stream outlet
+    # info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+    # info = StreamInfo('Markers', 'Markers', 1 + len(additional_labels), 0, 'int32', 'myuidw43536')
+    info = StreamInfo(
+        "Markers", "Markers", 1 + len(additional_labels), 0, "float32", "myuidw43536"
+    )
+
+    outlet = StreamOutlet(info)
+
+    # np.random.seed(random_state)
     markernames = [1, 2]
     start = time.time()
-    
+
     # Set up trial parameters
     record_duration = np.float32(duration)
 
     # Initialize stimuli
-    #aud1 = sound.Sound('C', octave=5, sampleRate=44100, secs=secs)
-    aud1 = sound.Sound(440,secs=secs)#, octave=5, sampleRate=44100, secs=secs)
+    # aud1 = sound.Sound('C', octave=5, sampleRate=44100, secs=secs)
+    aud1 = sound.Sound(440, secs=secs)  # , octave=5, sampleRate=44100, secs=secs)
     aud1.setVolume(volume)
-    
-    #aud2 = sound.Sound('D', octave=6, sampleRate=44100, secs=secs)
-    aud2 = sound.Sound(528,secs=secs)
+
+    # aud2 = sound.Sound('D', octave=6, sampleRate=44100, secs=secs)
+    aud2 = sound.Sound(528, secs=secs)
     aud2.setVolume(volume)
     auds = [aud1, aud2]
-    
+
     # Setup trial list
-    #sound_ind = np.random.binomial(1, 0.25, n_trials)
-    #itis = iti + np.random.rand(n_trials) * jitter
-    #trials = DataFrame(dict(sound_ind=sound_ind, iti=itis))
-    #trials['soa'] = soa
-    #trials['secs'] = secs
-    trials = DataFrame(dict(sound_ind=stim_types,iti=itis))
-    
-    for col_name,col_vec in additional_labels.items():
+    # sound_ind = np.random.binomial(1, 0.25, n_trials)
+    # itis = iti + np.random.rand(n_trials) * jitter
+    # trials = DataFrame(dict(sound_ind=sound_ind, iti=itis))
+    # trials['soa'] = soa
+    # trials['secs'] = secs
+    trials = DataFrame(dict(sound_ind=stim_types, iti=itis))
+
+    for col_name, col_vec in additional_labels.items():
         trials[col_name] = col_vec
-    
+
     # Setup graphics
-    mywin = visual.Window([1920, 1080], monitor='testMonitor', units='deg',
-                          fullscr=True)
-    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0,
-                                  rgb=[1, 0, 0])
+    mywin = visual.Window(
+        [1920, 1080], monitor="testMonitor", units="deg", fullscr=True
+    )
+    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0, rgb=[1, 0, 0])
     fixation.setAutoDraw(True)
     mywin.flip()
-    
-    
+
     for ii, trial in trials.iterrows():
-        
+
         # Intertrial interval
-        time.sleep(trial['iti'])
-        
+        time.sleep(trial["iti"])
+
         # Select and play sound
-        ind = int(trial['sound_ind'])
-        auds[ind].stop()        
+        ind = int(trial["sound_ind"])
+        auds[ind].stop()
         auds[ind].play()
 
         additional_stamps = []
         for k in additional_labels.keys():
             additional_stamps += [trial[k]]
-        
+
         # Send marker
         timestamp = time.time()
-        #outlet.push_sample([markernames[ind]], timestamp)
-        
-               
+        # outlet.push_sample([markernames[ind]], timestamp)
+
         outlet.push_sample(additional_stamps + [markernames[ind]], timestamp)
-        
+
         # Offset
-        #time.sleep(soa)
-        #if (time.time() - start) > record_duration:
+        # time.sleep(soa)
+        # if (time.time() - start) > record_duration:
         #    break
 
         # offset
-        #core.wait(soa)
-        
+        # core.wait(soa)
+
         if len(event.getKeys()) > 0 or (time.time() - start) > record_duration:
             break
         event.clearEvents()
-        
-        #if len(event.getKeys()) > 0 or (time() - start) > record_duration:
+
+        # if len(event.getKeys()) > 0 or (time() - start) > record_duration:
         #    break
-        #event.clearEvents()
-        
+        # event.clearEvents()
+
     # Cleanup
     mywin.close()
-        
-        
+
     return trials
 
 
@@ -111,39 +115,79 @@ def main():
     parser = OptionParser()
 
     parser.add_option(
-        '-d', '--duration', dest='duration', type='int', default=10,
-        help='duration of the recording in seconds.')
+        "-d",
+        "--duration",
+        dest="duration",
+        type="int",
+        default=10,
+        help="duration of the recording in seconds.",
+    )
     parser.add_option(
-        '-n', '--n_trials', dest='n_trials', type='int', 
-        default=10, help='number of trials.')
+        "-n",
+        "--n_trials",
+        dest="n_trials",
+        type="int",
+        default=10,
+        help="number of trials.",
+    )
     parser.add_option(
-        '-i', '--iti', dest='iti', type='float', default=0.3,
-        help='intertrial interval')
+        "-i", "--iti", dest="iti", type="float", default=0.3, help="intertrial interval"
+    )
     parser.add_option(
-        '-s', '--soa', dest='soa', type='float', default=0.2,
-        help='interval between end of stimulus and next trial.')
+        "-s",
+        "--soa",
+        dest="soa",
+        type="float",
+        default=0.2,
+        help="interval between end of stimulus and next trial.",
+    )
     parser.add_option(
-        '-j', '--jitter', dest='jitter', type='float', default=0.2,
-        help='jitter in the intertrial intervals.')
+        "-j",
+        "--jitter",
+        dest="jitter",
+        type="float",
+        default=0.2,
+        help="jitter in the intertrial intervals.",
+    )
     parser.add_option(
-        '-e', '--secs', dest='secs', type='float', default=0.2,
-        help='duration of the sound in seconds.')
+        "-e",
+        "--secs",
+        dest="secs",
+        type="float",
+        default=0.2,
+        help="duration of the sound in seconds.",
+    )
     parser.add_option(
-        '-v', '--volume', dest='volume', type='float', default=0.8,
-        help='volume of the sounds in [0, 1].')
+        "-v",
+        "--volume",
+        dest="volume",
+        type="float",
+        default=0.8,
+        help="volume of the sounds in [0, 1].",
+    )
     parser.add_option(
-        '-r', '--randomstate', dest='random_state', type='int', 
-        default=42, help='random seed')
+        "-r",
+        "--randomstate",
+        dest="random_state",
+        type="int",
+        default=42,
+        help="random seed",
+    )
 
     (options, args) = parser.parse_args()
     trials_df = present(
-        duration=options.duration, n_trials=options.duration, 
-        iti=options.iti, soa=options.soa, jitter=options.jitter,
-        secs=options.secs, volume=options.volume, 
-        random_state=options.random_state) 
+        duration=options.duration,
+        n_trials=options.duration,
+        iti=options.iti,
+        soa=options.soa,
+        jitter=options.jitter,
+        secs=options.secs,
+        volume=options.volume,
+        random_state=options.random_state,
+    )
 
     print(trials_df)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/experiments/auditory_oddball/auditory_erp_aux.py
+++ b/eegnb/experiments/auditory_oddball/auditory_erp_aux.py
@@ -9,13 +9,20 @@ from psychopy import visual, core, event, sound
 from pylsl import StreamInfo, StreamOutlet
 
 
-def present(duration=120, n_trials=10, iti=0.3, soa=0.2, jitter=0.2, 
-            secs=0.2, volume=0.8, random_state=None):
-    
+def present(
+    duration=120,
+    n_trials=10,
+    iti=0.3,
+    soa=0.2,
+    jitter=0.2,
+    secs=0.2,
+    volume=0.8,
+    random_state=None,
+):
 
     # Create markers stream outlet
-    info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
-    outlet = StreamOutlet(info)    
+    info = StreamInfo("Markers", "Markers", 1, 0, "int32", "myuidw43536")
+    outlet = StreamOutlet(info)
 
     np.random.seed(random_state)
     markernames = [1, 2]
@@ -25,9 +32,9 @@ def present(duration=120, n_trials=10, iti=0.3, soa=0.2, jitter=0.2,
     record_duration = np.float32(duration)
 
     # Initialize stimuli
-    aud1 = sound.Sound('C', octave=5, sampleRate=44100, secs=secs)
+    aud1 = sound.Sound("C", octave=5, sampleRate=44100, secs=secs)
     aud1.setVolume(volume)
-    aud2 = sound.Sound('D', octave=6, sampleRate=44100, secs=secs)
+    aud2 = sound.Sound("D", octave=6, sampleRate=44100, secs=secs)
     aud2.setVolume(volume)
     auds = [aud1, aud2]
 
@@ -35,26 +42,26 @@ def present(duration=120, n_trials=10, iti=0.3, soa=0.2, jitter=0.2,
     sound_ind = np.random.binomial(1, 0.25, n_trials)
     itis = iti + np.random.rand(n_trials) * jitter
     trials = DataFrame(dict(sound_ind=sound_ind, iti=itis))
-    trials['soa'] = soa
-    trials['secs'] = secs
+    trials["soa"] = soa
+    trials["secs"] = secs
 
     for ii, trial in trials.iterrows():
-        
+
         # Intertrial interval
-        time.sleep(trial['iti'])
+        time.sleep(trial["iti"])
 
         # Select and play sound
-        ind = int(trial['sound_ind'])
-        auds[ind].stop()        
+        ind = int(trial["sound_ind"])
+        auds[ind].stop()
         auds[ind].play()
 
         # Send marker
         timestamp = time.time()
         outlet.push_sample([markernames[ind]], timestamp)
-        
+
         # Offset
-        #time.sleep(soa)
-        #if (time.time() - start) > record_duration:
+        # time.sleep(soa)
+        # if (time.time() - start) > record_duration:
         #    break
 
         # offset
@@ -62,13 +69,11 @@ def present(duration=120, n_trials=10, iti=0.3, soa=0.2, jitter=0.2,
         if len(event.getKeys()) > 0 or (time.time() - start) > record_duration:
             break
         event.clearEvents()
-        
-        #if len(event.getKeys()) > 0 or (time() - start) > record_duration:
+
+        # if len(event.getKeys()) > 0 or (time() - start) > record_duration:
         #    break
-        #event.clearEvents()
-        
-        
-        
+        # event.clearEvents()
+
     return trials
 
 
@@ -76,39 +81,79 @@ def main():
     parser = OptionParser()
 
     parser.add_option(
-        '-d', '--duration', dest='duration', type='int', default=10,
-        help='duration of the recording in seconds.')
+        "-d",
+        "--duration",
+        dest="duration",
+        type="int",
+        default=10,
+        help="duration of the recording in seconds.",
+    )
     parser.add_option(
-        '-n', '--n_trials', dest='n_trials', type='int', 
-        default=10, help='number of trials.')
+        "-n",
+        "--n_trials",
+        dest="n_trials",
+        type="int",
+        default=10,
+        help="number of trials.",
+    )
     parser.add_option(
-        '-i', '--iti', dest='iti', type='float', default=0.3,
-        help='intertrial interval')
+        "-i", "--iti", dest="iti", type="float", default=0.3, help="intertrial interval"
+    )
     parser.add_option(
-        '-s', '--soa', dest='soa', type='float', default=0.2,
-        help='interval between end of stimulus and next trial.')
+        "-s",
+        "--soa",
+        dest="soa",
+        type="float",
+        default=0.2,
+        help="interval between end of stimulus and next trial.",
+    )
     parser.add_option(
-        '-j', '--jitter', dest='jitter', type='float', default=0.2,
-        help='jitter in the intertrial intervals.')
+        "-j",
+        "--jitter",
+        dest="jitter",
+        type="float",
+        default=0.2,
+        help="jitter in the intertrial intervals.",
+    )
     parser.add_option(
-        '-e', '--secs', dest='secs', type='float', default=0.2,
-        help='duration of the sound in seconds.')
+        "-e",
+        "--secs",
+        dest="secs",
+        type="float",
+        default=0.2,
+        help="duration of the sound in seconds.",
+    )
     parser.add_option(
-        '-v', '--volume', dest='volume', type='float', default=0.8,
-        help='volume of the sounds in [0, 1].')
+        "-v",
+        "--volume",
+        dest="volume",
+        type="float",
+        default=0.8,
+        help="volume of the sounds in [0, 1].",
+    )
     parser.add_option(
-        '-r', '--randomstate', dest='random_state', type='int', 
-        default=42, help='random seed')
+        "-r",
+        "--randomstate",
+        dest="random_state",
+        type="int",
+        default=42,
+        help="random seed",
+    )
 
     (options, args) = parser.parse_args()
     trials_df = present(
-        duration=options.duration, n_trials=options.duration, 
-        iti=options.iti, soa=options.soa, jitter=options.jitter,
-        secs=options.secs, volume=options.volume, 
-        random_state=options.random_state) 
+        duration=options.duration,
+        n_trials=options.duration,
+        iti=options.iti,
+        soa=options.soa,
+        jitter=options.jitter,
+        secs=options.secs,
+        volume=options.volume,
+        random_state=options.random_state,
+    )
 
     print(trials_df)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/experiments/auditory_ssaep/ssaep.py
+++ b/eegnb/experiments/auditory_ssaep/ssaep.py
@@ -13,8 +13,9 @@ from optparse import OptionParser
 import numpy as np
 from pandas import DataFrame
 from psychopy import prefs
-prefs.general['audioLib'] = ['pygame']
-#prefs.hardware['audioLib'] = ['PTB', 'pyo','pygame']
+
+prefs.general["audioLib"] = ["pygame"]
+# prefs.hardware['audioLib'] = ['PTB', 'pyo','pygame']
 from psychopy import visual, core, event, sound
 from pylsl import StreamInfo, StreamOutlet
 from scipy import stats
@@ -27,13 +28,24 @@ from random import choice
 from eegnb import generate_save_fn
 
 
-def present(duration=120, eeg=None, save_fn=None, iti = 0.5, soa = 3.0, jitter = 0.2, 
-            n_trials = 2010, cf1 = 900, amf1 = 45, cf2 = 770, amf2 = 40.018):
+def present(
+    duration=120,
+    eeg=None,
+    save_fn=None,
+    iti=0.5,
+    soa=3.0,
+    jitter=0.2,
+    n_trials=2010,
+    cf1=900,
+    amf1=45,
+    cf2=770,
+    amf2=40.018,
+):
 
-    sample_rate=44100
+    sample_rate = 44100
 
     # Create markers stream outlet
-    info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+    info = StreamInfo("Markers", "Markers", 1, 0, "int32", "myuidw43536")
     outlet = StreamOutlet(info)
 
     markernames = [1, 2]
@@ -47,15 +59,20 @@ def present(duration=120, eeg=None, save_fn=None, iti = 0.5, soa = 3.0, jitter =
     trials = DataFrame(dict(stim_freq=stim_freq, timestamp=np.zeros(n_trials)))
 
     # Setup graphics
-    mywin = visual.Window([1920, 1080], monitor='testMonitor', units='deg',
-                          fullscr=True)
-    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0,
-                                  rgb=[1, 0, 0])
+    mywin = visual.Window(
+        [1920, 1080], monitor="testMonitor", units="deg", fullscr=True
+    )
+    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0, rgb=[1, 0, 0])
     fixation.setAutoDraw(True)
 
-
-    def generate_am_waveform(carrier_freq, am_freq, secs=1, sample_rate=sample_rate,
-                             am_type='gaussian', gaussian_std_ratio=8):
+    def generate_am_waveform(
+        carrier_freq,
+        am_freq,
+        secs=1,
+        sample_rate=sample_rate,
+        am_type="gaussian",
+        gaussian_std_ratio=8,
+    ):
         """Generate an amplitude-modulated waveform.
 
         Generate a sine wave amplitude-modulated by a second sine wave or a
@@ -79,18 +96,18 @@ def present(duration=120, eeg=None, save_fn=None, iti = 0.5, soa = 3.0, jitter =
         Returns:
             (numpy.ndarray): sound samples
         """
-        t = np.arange(0, secs, 1./sample_rate)
+        t = np.arange(0, secs, 1.0 / sample_rate)
 
-        if am_type == 'gaussian':
+        if am_type == "gaussian":
             period = int(sample_rate / am_freq)
             std = period / gaussian_std_ratio
             norm_window = stats.norm.pdf(np.arange(period), period / 2, std)
             norm_window /= np.max(norm_window)
             n_windows = int(np.ceil(secs * am_freq))
             am = np.tile(norm_window, n_windows)
-            am = am[:len(t)]
+            am = am[: len(t)]
 
-        elif am_type == 'sine':
+        elif am_type == "sine":
             am = np.sin(2 * np.pi * am_freq * t)
 
         carrier = 0.5 * np.sin(2 * np.pi * carrier_freq * t) + 0.5
@@ -98,46 +115,46 @@ def present(duration=120, eeg=None, save_fn=None, iti = 0.5, soa = 3.0, jitter =
 
         return am_out
 
-
     # Generate stimuli
     am1 = generate_am_waveform(cf1, amf1, secs=soa, sample_rate=sample_rate)
     am2 = generate_am_waveform(cf2, amf2, secs=soa, sample_rate=sample_rate)
 
-    aud1 = sound.Sound(am1,sampleRate=sample_rate)
+    aud1 = sound.Sound(am1, sampleRate=sample_rate)
     aud1.setVolume(0.8)
-    aud2 = sound.Sound(am2,sampleRate=sample_rate)
+    aud2 = sound.Sound(am2, sampleRate=sample_rate)
     aud2.setVolume(0.8)
     auds = [aud1, aud2]
 
     mywin.flip()
-    
+
     # start the EEG stream=
     if eeg:
         if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
-            save_fn = generate_save_fn(eeg.device_name, 'ssaep', 'unnamed')
-            print(f'No path for a save file was passed to the experiment. Saving data to {save_fn}')
-        eeg.start(save_fn,duration=record_duration)
-    
+            save_fn = generate_save_fn(eeg.device_name, "ssaep", "unnamed")
+            print(
+                f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
+            )
+        eeg.start(save_fn, duration=record_duration)
 
     for ii, trial in trials.iterrows():
         # Intertrial interval
         core.wait(iti + np.random.rand() * jitter)
 
         # Select stimulus frequency
-        ind = trials['stim_freq'].iloc[ii]
-        auds[ind].stop() 
+        ind = trials["stim_freq"].iloc[ii]
+        auds[ind].stop()
         auds[ind].play()
-        
+
         # Push sample
-        if eeg: 
+        if eeg:
             timestamp = time()
-            if eeg.backend == 'muselsl':
+            if eeg.backend == "muselsl":
                 marker = [markernames[ind]]
-                marker = list(map(int, marker)) 
+                marker = list(map(int, marker))
             else:
                 marker = markernames[ind]
             eeg.push_sample(marker=marker, timestamp=timestamp)
-            
+
         # offset
         core.wait(soa)
         mywin.flip()
@@ -147,9 +164,9 @@ def present(duration=120, eeg=None, save_fn=None, iti = 0.5, soa = 3.0, jitter =
             break
 
         event.clearEvents()
-        
+
     # Cleanup
-    if eeg: eeg.stop()
+    if eeg:
+        eeg.stop()
 
     mywin.close()
-

--- a/eegnb/experiments/visual_baselinetask/baseline_task.py
+++ b/eegnb/experiments/visual_baselinetask/baseline_task.py
@@ -6,42 +6,53 @@ import random
 import numpy as np
 from pandas import DataFrame
 from psychopy import prefs
-prefs.general['audioLib'] = ['pygame']
+
+prefs.general["audioLib"] = ["pygame"]
 from psychopy import visual, core, event, sound
 from pylsl import StreamInfo, StreamOutlet, local_clock
 
 # Create markers stream outlet
-info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+info = StreamInfo("Markers", "Markers", 1, 0, "int32", "myuidw43536")
 outlet = StreamOutlet(info)
 
 start = time()
 
 # Initialize stimuli
-aud1 = sound.Sound('C', octave=5, sampleRate=44100, secs=0.5, bits=8)
+aud1 = sound.Sound("C", octave=5, sampleRate=44100, secs=0.5, bits=8)
 aud1.setVolume(0.025)
 
 # Setup graphics
-mywin = visual.Window([1440, 900], monitor='testMonitor', units='deg',
-                      fullscr=True)
+mywin = visual.Window([1440, 900], monitor="testMonitor", units="deg", fullscr=True)
 
-#Hide the mouse cursor
+# Hide the mouse cursor
 mywin.mouseVisible = False
 
-#define the length of each block
+# define the length of each block
 exp_length = 20.0
 
-#randomly pick our condition order
-cond_order = random.randint(1,2)
+# randomly pick our condition order
+cond_order = random.randint(1, 2)
 
-#setup our instructions
-instr1 = visual.TextStim(mywin,text='Keep your eyes open for 20 seconds and focus on the central fixation. You CAN blink during this time. Press the spacebar to begin.',pos=(0,-3))
-instr2 = visual.TextStim(mywin,text='Keep your eyes closed for 20 seconds, Open them when you hear a long beep/tone. Close them and press the spacebar to begin.',pos=(0,-3))
-instr3 = visual.TextStim(mywin,text='Keep your eyes closed at this time.',pos=(0,-3))
-instr4 = visual.TextStim(mywin,text='You have finished the experiment! Press the spacebar to exit.',pos=(0,-3))
+# setup our instructions
+instr1 = visual.TextStim(
+    mywin,
+    text="Keep your eyes open for 20 seconds and focus on the central fixation. You CAN blink during this time. Press the spacebar to begin.",
+    pos=(0, -3),
+)
+instr2 = visual.TextStim(
+    mywin,
+    text="Keep your eyes closed for 20 seconds, Open them when you hear a long beep/tone. Close them and press the spacebar to begin.",
+    pos=(0, -3),
+)
+instr3 = visual.TextStim(mywin, text="Keep your eyes closed at this time.", pos=(0, -3))
+instr4 = visual.TextStim(
+    mywin,
+    text="You have finished the experiment! Press the spacebar to exit.",
+    pos=(0, -3),
+)
 
-#setup the fixation
-fixation = visual.GratingStim(win=mywin, size=0.1, pos=[0, 0], sf=0,
-                              rgb=[1, 1, 1])
+# setup the fixation
+fixation = visual.GratingStim(win=mywin, size=0.1, pos=[0, 0], sf=0, rgb=[1, 1, 1])
 
 core.wait(2)
 
@@ -49,25 +60,25 @@ if cond_order == 1:
     timestamp = local_clock()
     outlet.push_sample([1], timestamp)
     core.wait(1)
-    #display instructions for the first eyes-open block
+    # display instructions for the first eyes-open block
     instr1.setAutoDraw(True)
     fixation.setAutoDraw(True)
     mywin.flip()
     event.waitKeys()
-    
-    #start the first eyes-open block
+
+    # start the first eyes-open block
     instr1.setAutoDraw(False)
     mywin.flip()
     timestamp = local_clock()
     outlet.push_sample([11], timestamp)
     core.wait(exp_length)
-    
-    #display instructions for the first eyes-closed block
+
+    # display instructions for the first eyes-closed block
     instr2.setAutoDraw(True)
     mywin.flip()
     event.waitKeys()
-    
-    #start first eyes-closed block
+
+    # start first eyes-closed block
     instr2.setAutoDraw(False)
     instr3.setAutoDraw(True)
     mywin.flip()
@@ -77,18 +88,18 @@ if cond_order == 1:
     core.wait(exp_length)
     aud1.play()
 
-    
+
 elif cond_order == 2:
     timestamp = local_clock()
     outlet.push_sample([2], timestamp)
     core.wait(1)
-    #display instructions for the first eyes-closed block
+    # display instructions for the first eyes-closed block
     fixation.setAutoDraw(True)
     instr2.setAutoDraw(True)
     mywin.flip()
     event.waitKeys()
-    
-    #start first eyes-closed block
+
+    # start first eyes-closed block
     instr2.setAutoDraw(False)
     instr3.setAutoDraw(True)
     mywin.flip()
@@ -97,24 +108,23 @@ elif cond_order == 2:
     aud1.play()
     core.wait(exp_length)
     aud1.play()
-    
-    #display instructions for the first eyes-open block
+
+    # display instructions for the first eyes-open block
     instr3.setAutoDraw(False)
     instr1.setAutoDraw(True)
     fixation.setAutoDraw(True)
     mywin.flip()
     event.waitKeys()
-    
-    #start the first eyes-open block
+
+    # start the first eyes-open block
     instr1.setAutoDraw(False)
     mywin.flip()
     timestamp = local_clock()
     outlet.push_sample([11], timestamp)
     core.wait(exp_length)
-    
-   
 
-#display end screen
+
+# display end screen
 instr3.setAutoDraw(False)
 instr4.setAutoDraw(True)
 mywin.flip()

--- a/eegnb/experiments/visual_cueing/cueing.py
+++ b/eegnb/experiments/visual_cueing/cueing.py
@@ -8,9 +8,10 @@ import scipy.io
 import os
 import sys
 
-def present(duration,subject,session):
+
+def present(duration, subject, session):
     # create
-    info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+    info = StreamInfo("Markers", "Markers", 1, 0, "int32", "myuidw43536")
 
     # next make an outlet
     outlet = StreamOutlet(info)
@@ -20,23 +21,23 @@ def present(duration,subject,session):
     # 1 - Cue Left, 2 - Cue Right
     cue_markernames = [1, 2]
     # 31 - incorrect, 32 - Correct
-    resp_markernames = [31,32]
+    resp_markernames = [31, 32]
 
     n_trials = 2010
     instruct = 1
     practicing = 1
 
-    #seconds
+    # seconds
     iti = 1
     iti_jitter = 0.2
     cue_target = 1.5
-    cue_target_jitter = .5
-    target_length = 0.05 
+    cue_target_jitter = 0.5
+    target_length = 0.05
 
-    cue_validity = .80
+    cue_validity = 0.80
     record_duration = np.float32(duration)
 
-    target_positions = [-10,10]
+    target_positions = [-10, 10]
     target_size = [1]
 
     # Setup log
@@ -45,66 +46,64 @@ def present(duration,subject,session):
 
     trials = DataFrame(dict(tilt=tilt, cues=cues))
 
-    #Instructions function below
+    # Instructions function below
     if instruct:
         instructions()
     if practicing:
         practice()
 
     # graphics
-    mywin = visual.Window([1440, 900], monitor="testMonitor", units="deg",
-                          fullscr=True)
+    mywin = visual.Window([1440, 900], monitor="testMonitor", units="deg", fullscr=True)
 
     mywin.mouseVisible = False
 
-    grating = visual.GratingStim(win=mywin, mask='gauss', size=target_size, sf=5)
-    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0)                            
-    cuewin = visual.GratingStim(win=mywin, mask='circle', size=0.5, pos=[0, 1], sf=0)
+    grating = visual.GratingStim(win=mywin, mask="gauss", size=target_size, sf=5)
+    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0)
+    cuewin = visual.GratingStim(win=mywin, mask="circle", size=0.5, pos=[0, 1], sf=0)
 
-    #saving trial information for output
+    # saving trial information for output
     responses = []
 
-    #Get ready screen
+    # Get ready screen
     text = visual.TextStim(
         win=mywin,
         text="Find the arrow keys, and begin fixating now. The first trial is about to begin",
         color=[-1, -1, -1],
-        pos= [0,5])
+        pos=[0, 5],
+    )
     text.draw()
     fixation.draw()
     mywin.flip()
     core.wait(3)
-   
 
-    #create a clock for rt's
+    # create a clock for rt's
     clock = core.Clock()
-    #create a timer for the experiment and EEG markers
+    # create a timer for the experiment and EEG markers
     start = time()
 
     for ii, trial in trials.iterrows():
 
-        til = trials['tilt'].iloc[ii]
-        cue = trials['cues'].iloc[ii]
+        til = trials["tilt"].iloc[ii]
+        cue = trials["cues"].iloc[ii]
         # cue direction, pick target side
         if cue:
-            cuewin.color = [1,0,0]
+            cuewin.color = [1, 0, 0]
             pos = int(np.random.binomial(1, cue_validity, 1))
         else:
-            cuewin.color = [0,0,1]
-            pos = int(np.random.binomial(1, 1-cue_validity, 1))
-        # create target    
+            cuewin.color = [0, 0, 1]
+            pos = int(np.random.binomial(1, 1 - cue_validity, 1))
+        # create target
         if pos:
-            grating.pos = [10,0]
+            grating.pos = [10, 0]
         else:
-            grating.pos = [-10,0]
+            grating.pos = [-10, 0]
 
-        # 1- Valid cue, 0 - Invalid    
-        validity = int(not abs(cue-pos))
+        # 1- Valid cue, 0 - Invalid
+        validity = int(not abs(cue - pos))
 
-        #til, 1 - Horizontal, 0 - Vertical
+        # til, 1 - Horizontal, 0 - Vertical
         grating.ori = 90 * til
         grating.phase += np.random.rand()
-
 
         ## Trial starts here ##
         # inter trial interval
@@ -126,7 +125,7 @@ def present(duration,subject,session):
         t_targetOnset = time()
 
         # 11-InvalidLeft; 12-InvalidRight; 21-ValidLeft; 22-ValidRight
-        outlet.push_sample([markernames[pos+(validity*2)]], t_targetOnset)
+        outlet.push_sample([markernames[pos + (validity * 2)]], t_targetOnset)
         mywin.flip()
 
         # response period
@@ -135,90 +134,114 @@ def present(duration,subject,session):
         t_respOnset = clock.getTime()
         mywin.flip()
 
-        #Wait for response
-        keys = event.waitKeys(keyList=["right","up"], timeStamped=clock)
-        #categorize response
+        # Wait for response
+        keys = event.waitKeys(keyList=["right", "up"], timeStamped=clock)
+        # categorize response
         correct = 1
-        response = 1 
-        #if validity:
-            #print("Valid Target")
-        #else:
-            #print("Invalid Target")
-            
-        if keys[0][0] == 'right':
-            #print("pressed horizontal")
+        response = 1
+        # if validity:
+        # print("Valid Target")
+        # else:
+        # print("Invalid Target")
+
+        if keys[0][0] == "right":
+            # print("pressed horizontal")
             response = 1
             if til:
-                #print("Correct")
+                # print("Correct")
                 correct = 1
             else:
-                #print("Incorrect")
-                #play sound
-                sys.stdout.write('\a')
+                # print("Incorrect")
+                # play sound
+                sys.stdout.write("\a")
                 correct = 0
-        elif keys[0][0] == 'up':
-            #print("pressed vertical")
+        elif keys[0][0] == "up":
+            # print("pressed vertical")
             response = 0
             if til:
-                #print("Incorrect")
-                sys.stdout.write('\a')
+                # print("Incorrect")
+                sys.stdout.write("\a")
                 correct = 0
             else:
-                #print("Correct")
+                # print("Correct")
                 correct = 1
 
-        #reset sound        
+        # reset sound
         sys.stdout.flush()
 
-        #meausure RT        
-        rt = keys[0][1] - t_respOnset;
-        #print("RT = " + str(np.round(rt*1000)) + " ms")
+        # meausure RT
+        rt = keys[0][1] - t_respOnset
+        # print("RT = " + str(np.round(rt*1000)) + " ms")
 
-        #save variables
-        tempArray = [ii+1, cue, pos, validity, til, response, correct, rt*1000]
-        #print(tempArray)
+        # save variables
+        tempArray = [ii + 1, cue, pos, validity, til, response, correct, rt * 1000]
+        # print(tempArray)
         responses.append(tempArray)
-        column_labels = ["trial","cue direction","target position", "cue validity", "target tilt", "response","accuracy","rt"]
-        #trial number (start at 1)
-        #Pos, cue - 1 right 
-        #validity - 1 valid
-        #til = 1 - horizontal; 0 - vertical
-        #response - 1 right arrow (horizontal); 0 up arrow (vertical)
-        #correct - 1 correct, 0 incorrect
-        #rt - ms
+        column_labels = [
+            "trial",
+            "cue direction",
+            "target position",
+            "cue validity",
+            "target tilt",
+            "response",
+            "accuracy",
+            "rt",
+        ]
+        # trial number (start at 1)
+        # Pos, cue - 1 right
+        # validity - 1 valid
+        # til = 1 - horizontal; 0 - vertical
+        # response - 1 right arrow (horizontal); 0 up arrow (vertical)
+        # correct - 1 correct, 0 incorrect
+        # rt - ms
 
-         # block end
+        # block end
         if (time() - start) > record_duration:
             break
         event.clearEvents()
 
-
-    #save the behavioural data into matlab file 
-    directory = os.path.join(os.path.expanduser("~"), "eeg-notebooks", "data", "visual", "cueing", "subject" + str(subject), "session" + str(session)) 
+    # save the behavioural data into matlab file
+    directory = os.path.join(
+        os.path.expanduser("~"),
+        "eeg-notebooks",
+        "data",
+        "visual",
+        "cueing",
+        "subject" + str(subject),
+        "session" + str(session),
+    )
     if not os.path.exists(directory):
         os.makedirs(directory)
-    outname = os.path.join(directory, "subject" + str(subject) + "_session" + str(session) + ("_behOutput_%s.mat" % strftime("%Y-%m-%d-%H.%M.%S", gmtime())))    
+    outname = os.path.join(
+        directory,
+        "subject"
+        + str(subject)
+        + "_session"
+        + str(session)
+        + ("_behOutput_%s.mat" % strftime("%Y-%m-%d-%H.%M.%S", gmtime())),
+    )
     output = np.array(responses)
-    scipy.io.savemat(outname, {'output': output, 'column_labels':column_labels})
-   
-    #Overall Accuracy
-    print("Overall Mean Accuracy = " + str(round(100*np.mean(output[:,6]))))
-    #Overall Mean, Median RT
-    print("Overall Mean RT = " + str(round(np.mean(output[:,7]))))
-    print("Overall Median RT = " + str(round(np.median(output[:,7]))))
+    scipy.io.savemat(outname, {"output": output, "column_labels": column_labels})
+
+    # Overall Accuracy
+    print("Overall Mean Accuracy = " + str(round(100 * np.mean(output[:, 6]))))
+    # Overall Mean, Median RT
+    print("Overall Mean RT = " + str(round(np.mean(output[:, 7]))))
+    print("Overall Median RT = " + str(round(np.median(output[:, 7]))))
 
     ## Mean RT
-    print("Valid Mean RT = " + str(round(np.mean(output[output[:,3] == 1,7]))))
-    print("Invalid Mean RT = " + str(round(np.mean(output[output[:,3] == 0,7]))))
-    print("Valid Median RT = " + str(round(np.median(output[output[:,3] == 1,7]))))
-    print("Invalid Median RT = " + str(round(np.median(output[output[:,3] == 0,7]))))
+    print("Valid Mean RT = " + str(round(np.mean(output[output[:, 3] == 1, 7]))))
+    print("Invalid Mean RT = " + str(round(np.mean(output[output[:, 3] == 0, 7]))))
+    print("Valid Median RT = " + str(round(np.median(output[output[:, 3] == 1, 7]))))
+    print("Invalid Median RT = " + str(round(np.median(output[output[:, 3] == 0, 7]))))
 
-    #Goodbye Screen
+    # Goodbye Screen
     text = visual.TextStim(
         win=mywin,
         text="Thank you for participating. Press spacebar to exit the experiment.",
         color=[-1, -1, -1],
-        pos= [0,5])
+        pos=[0, 5],
+    )
     text.draw()
     mywin.flip()
     event.waitKeys(keyList="space")
@@ -229,24 +252,23 @@ def present(duration,subject,session):
     mywin.close()
 
 
-
 def practice():
 
     practice_duration = 20
     n_trials = 2010
 
-    #seconds
+    # seconds
     iti = 1
     iti_jitter = 0.2
     cue_target = 1.5
-    cue_target_jitter = .5
-    target_length = 0.2 
+    cue_target_jitter = 0.5
+    target_length = 0.2
 
-    cue_validity = .99
+    cue_validity = 0.99
 
     record_duration = np.float32(practice_duration)
 
-    target_positions = [-10,10]
+    target_positions = [-10, 10]
     target_size = [2]
 
     # Setup log
@@ -257,54 +279,53 @@ def practice():
 
     # graphics
     mywin = visual.Window([1440, 900], monitor="testMonitor", units="deg", fullscr=True)
-    grating = visual.GratingStim(win=mywin, mask='gauss', size=2, sf=4)
-    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0)                            
-    cuewin = visual.GratingStim(win=mywin, mask='circle', size=0.5, pos=[0, 1], sf=0)
-
+    grating = visual.GratingStim(win=mywin, mask="gauss", size=2, sf=4)
+    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0)
+    cuewin = visual.GratingStim(win=mywin, mask="circle", size=0.5, pos=[0, 1], sf=0)
 
     mywin.mouseVisible = False
 
-   #Get ready screen
+    # Get ready screen
     text = visual.TextStim(
         win=mywin,
         text="Find the arrow keys, and begin fixating now. The first practice trial is about to begin",
         color=[-1, -1, -1],
-        pos= [0,5])
+        pos=[0, 5],
+    )
 
     text.draw()
     fixation.draw()
     mywin.flip()
     core.wait(5)
-   
-    #create a clock for rt's
+
+    # create a clock for rt's
     clock = core.Clock()
-    #create a timer for the experiment and EEG markers
+    # create a timer for the experiment and EEG markers
     start = time()
 
     for ii, trial in trials.iterrows():
 
-        til = trials['tilt'].iloc[ii]
-        cue = trials['cues'].iloc[ii]
+        til = trials["tilt"].iloc[ii]
+        cue = trials["cues"].iloc[ii]
         # cue direction, pick target side
         if cue:
-            cuewin.color = [1,0,0]
+            cuewin.color = [1, 0, 0]
             pos = int(np.random.binomial(1, cue_validity, 1))
         else:
-            cuewin.color = [0,0,1]
-            pos = int(np.random.binomial(1, 1-cue_validity, 1))
-        # create target    
+            cuewin.color = [0, 0, 1]
+            pos = int(np.random.binomial(1, 1 - cue_validity, 1))
+        # create target
         if pos:
-            grating.pos = [10,0]
+            grating.pos = [10, 0]
         else:
-            grating.pos = [-10,0]
+            grating.pos = [-10, 0]
 
-        # 1- Valid cue, 0 - Invalid    
-        validity = int(not abs(cue-pos))
+        # 1- Valid cue, 0 - Invalid
+        validity = int(not abs(cue - pos))
 
-        #til, 1 - Horizontal, 0 - Vertical
+        # til, 1 - Horizontal, 0 - Vertical
         grating.ori = 90 * til
         grating.phase += np.random.rand()
-
 
         ## Trial starts here ##
         # inter trial interval
@@ -330,39 +351,39 @@ def practice():
         fixation.draw()
         mywin.flip()
 
-        #Wait for response
-        keys = event.waitKeys(keyList=["right","up"], timeStamped=clock)
-        #categorize response
+        # Wait for response
+        keys = event.waitKeys(keyList=["right", "up"], timeStamped=clock)
+        # categorize response
         correct = 1
-        response = 1 
-        #if validity:
-            #print("Valid Target")
-        #else:
-            #print("Invalid Target")
-            
-        if keys[0][0] == 'right':
-            #print("pressed horizontal")
+        response = 1
+        # if validity:
+        # print("Valid Target")
+        # else:
+        # print("Invalid Target")
+
+        if keys[0][0] == "right":
+            # print("pressed horizontal")
             response = 1
             if til:
-                #print("Correct")
+                # print("Correct")
                 correct = 1
             else:
-                #print("Incorrect")
-                #play sound
-                sys.stdout.write('\a')
+                # print("Incorrect")
+                # play sound
+                sys.stdout.write("\a")
                 correct = 0
-        elif keys[0][0] == 'up':
-            #print("pressed vertical")
+        elif keys[0][0] == "up":
+            # print("pressed vertical")
             response = 0
             if til:
-                #print("Incorrect")
-                sys.stdout.write('\a')
+                # print("Incorrect")
+                sys.stdout.write("\a")
                 correct = 0
             else:
-                #print("Correct")
+                # print("Correct")
                 correct = 1
 
-        #reset sound        
+        # reset sound
         sys.stdout.flush()
 
         # block end
@@ -370,13 +391,14 @@ def practice():
             break
         event.clearEvents()
 
-    #End Practice Screen
+    # End Practice Screen
     text = visual.TextStim(
         win=mywin,
         text="That is the end of the practice, Please let the experimenter know if you have any questions. Press Spacebar to begin the first trial.",
         color=[-1, -1, -1],
-        pos= [0,5])
-    
+        pos=[0, 5],
+    )
+
     text.draw()
     fixation.draw()
     mywin.flip()
@@ -391,32 +413,32 @@ def practice():
 def instructions():
 
     # graphics
-    mywin = visual.Window([1440, 900], monitor="testMonitor", units="deg",
-                          fullscr=True)
-    grating = visual.GratingStim(win=mywin, mask='gauss', size=2, sf=4)
-    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0)                            
-    cuewin = visual.GratingStim(win=mywin, mask='circle', size=0.5, pos=[0, 1], sf=0)
-
+    mywin = visual.Window([1440, 900], monitor="testMonitor", units="deg", fullscr=True)
+    grating = visual.GratingStim(win=mywin, mask="gauss", size=2, sf=4)
+    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0)
+    cuewin = visual.GratingStim(win=mywin, mask="circle", size=0.5, pos=[0, 1], sf=0)
 
     mywin.mouseVisible = False
 
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="Welcome to the Attention Experiment!, Press spacebar to continue",
-        color=[-1, -1, -1])
+        color=[-1, -1, -1],
+    )
     text.draw()
     mywin.flip()
     event.waitKeys(keyList="space")
 
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="These are these are the stimuli you will see on each trial.",
         color=[-1, -1, -1],
-        pos= [0,5])
-    grating.pos = [10,0]
-    cuewin.color = [1,0,0]
+        pos=[0, 5],
+    )
+    grating.pos = [10, 0]
+    cuewin.color = [1, 0, 0]
     grating.draw()
     cuewin.draw()
     fixation.draw()
@@ -424,54 +446,57 @@ def instructions():
     mywin.flip()
     event.waitKeys(keyList="space")
 
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="Each trial will begin with the white fixation point, keep your eyes focused on this position the entire trial. Try not to blink. Keep still. ",
         color=[-1, -1, -1],
-        pos= [0,5])
+        pos=[0, 5],
+    )
     text.draw()
     fixation.draw()
     mywin.flip()
     event.waitKeys(keyList="space")
 
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="After a moment, a coloured circle will appear above the fixation. This is your attention cue. If it is RED, the target will more likely appear on the RIGHT",
         color=[-1, -1, -1],
-        pos= [0,5])
-    cuewin.color = [1,0,0]
+        pos=[0, 5],
+    )
+    cuewin.color = [1, 0, 0]
     cuewin.draw()
     text.draw()
     fixation.draw()
     mywin.flip()
     event.waitKeys(keyList="space")
 
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="If it is BLUE, the target will more likely appear on the LEFT, sometimes the target can still appear at the unattended side.",
         color=[-1, -1, -1],
-        pos= [0,5])
-    cuewin.color = [0,0,1]
+        pos=[0, 5],
+    )
+    cuewin.color = [0, 0, 1]
     cuewin.draw()
     text.draw()
     fixation.draw()
     mywin.flip()
     event.waitKeys(keyList="space")
 
-
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="After another delay, the target will briefly appear, most often in the side cued by the coloured circle. The target can either be tilted vertically like this...",
         color=[-1, -1, -1],
-        pos= [0,5])
+        pos=[0, 5],
+    )
     til = 0
     grating.ori = 90 * til
-    grating.pos = [10,0]
-    cuewin.color = [1,0,0]
+    grating.pos = [10, 0]
+    cuewin.color = [1, 0, 0]
     grating.draw()
     cuewin.draw()
     text.draw()
@@ -479,16 +504,17 @@ def instructions():
     mywin.flip()
     event.waitKeys(keyList="space")
 
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="Or Horizontally like this. Your task is to press the RIGHT ARROW if the target is horizontal ",
         color=[-1, -1, -1],
-        pos= [0,5])
+        pos=[0, 5],
+    )
     til = 1
     grating.ori = 90 * til
-    grating.pos = [-10,0]
-    cuewin.color = [0,0,1]
+    grating.pos = [-10, 0]
+    cuewin.color = [0, 0, 1]
     grating.draw()
     cuewin.draw()
     text.draw()
@@ -496,16 +522,17 @@ def instructions():
     mywin.flip()
     event.waitKeys(keyList="space")
 
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="Or the UP ARROW if it is vertical. You should respond as fast and accurately as you can. Respond no matter which side the target appears, cued or uncued, left or right. ",
         color=[-1, -1, -1],
-        pos= [0,5])
+        pos=[0, 5],
+    )
     til = 0
     grating.ori = 90 * til
-    grating.pos = [-10,0]
-    cuewin.color = [0,0,1]
+    grating.pos = [-10, 0]
+    cuewin.color = [0, 0, 1]
     grating.draw()
     cuewin.draw()
     text.draw()
@@ -513,17 +540,18 @@ def instructions():
     mywin.flip()
     event.waitKeys(keyList="space")
 
-    #Instructions
+    # Instructions
     text = visual.TextStim(
         win=mywin,
         text="After you respond, you will hear a beep if you indicated the wrong direction, and the next trial begins with the fixation cross. You will complete a block of trials. Press Spacebar to begin the practice.",
         color=[-1, -1, -1],
-        pos= [0,5])
+        pos=[0, 5],
+    )
     fixation.draw()
     text.draw()
     mywin.flip()
-    #play sound
-    sys.stdout.write('\a')
+    # play sound
+    sys.stdout.write("\a")
     sys.stdout.flush()
 
     event.waitKeys(keyList="space")
@@ -536,15 +564,30 @@ def instructions():
 def main():
     parser = OptionParser()
 
-    parser.add_option("-d", "--duration",
-                      dest="duration", type='int', default=120,
-                      help="duration of the recording in seconds.")
-    parser.add_option("-s", "--subject",
-                  dest="subject", type='int', default=1,
-                  help="subject number: must be an integer")
-    parser.add_option("-r", "--run",
-                  dest="run", type='int', default=1,
-                  help="run (session) number: must be an integer")
+    parser.add_option(
+        "-d",
+        "--duration",
+        dest="duration",
+        type="int",
+        default=120,
+        help="duration of the recording in seconds.",
+    )
+    parser.add_option(
+        "-s",
+        "--subject",
+        dest="subject",
+        type="int",
+        default=1,
+        help="subject number: must be an integer",
+    )
+    parser.add_option(
+        "-r",
+        "--run",
+        dest="run",
+        type="int",
+        default=1,
+        help="run (session) number: must be an integer",
+    )
 
     (options, args) = parser.parse_args()
     present(options.duration)
@@ -552,5 +595,5 @@ def main():
     present(options.n)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/experiments/visual_gonogo/go_nogo.py
+++ b/eegnb/experiments/visual_gonogo/go_nogo.py
@@ -14,13 +14,13 @@ import scipy.io
 
 def present(subject, session, duration=120):
 
-    outdir = os.getcwd() + '/response_files/'
+    outdir = os.getcwd() + "/response_files/"
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
     ########################### more muse-lsl code ########################################
     # create
-    info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+    info = StreamInfo("Markers", "Markers", 1, 0, "int32", "myuidw43536")
     # next make an outlet
     outlet = StreamOutlet(info)
     markernames = [1, 2]
@@ -34,12 +34,13 @@ def present(subject, session, duration=120):
     def loadImage(filename):
         return visual.ImageStim(win=mywin, image=filename)
 
-    mywin = visual.Window([900, 500], monitor="testMonitor",
-                          units="deg", fullscr=False)
+    mywin = visual.Window([900, 500], monitor="testMonitor", units="deg", fullscr=False)
     targets = list(
-        map(loadImage, glob('stimulus_presentation/stim/cats_dogs/target-*.jpg')))
+        map(loadImage, glob("stimulus_presentation/stim/cats_dogs/target-*.jpg"))
+    )
     nontargets = list(
-        map(loadImage, glob('stimulus_presentation/stim/cats_dogs/nontarget-*.jpg')))
+        map(loadImage, glob("stimulus_presentation/stim/cats_dogs/nontarget-*.jpg"))
+    )
 
     #######################################################################################
 
@@ -49,64 +50,139 @@ def present(subject, session, duration=120):
     params = {
         # Declare stimulus and response parameters
         # time when stimulus is presented (in seconds)
-        'stimDur': .8,
+        "stimDur": 0.8,
         # time between when one stimulus disappears and the next appears (in seconds)
-        'ISI': .5,
-        'tStartup': 3,            # pause time before starting first stimulus
-        'tCoolDown': 2,           # pause time after end of last stimulus before "the end" text
-        'triggerKey': 't',        # key from scanner that says scan is starting
+        "ISI": 0.5,
+        "tStartup": 3,  # pause time before starting first stimulus
+        "tCoolDown": 2,  # pause time after end of last stimulus before "the end" text
+        "triggerKey": "t",  # key from scanner that says scan is starting
         # keys to be used for responses (mapped to 1,2,3,4)
-        'respKeys': ['space'],
-        'goStim': 'square',       # shape signaling respond
-        'noGoStim': 'diamond',    # shape signaling don't respond
-        'goStimProb': 0.75,        # probability of a given trial being a 'go' trial
+        "respKeys": ["space"],
+        "goStim": "square",  # shape signaling respond
+        "noGoStim": "diamond",  # shape signaling don't respond
+        "goStimProb": 0.75,  # probability of a given trial being a 'go' trial
         # declare prompt and question files
-        'skipPrompts': False,     # go right to the scanner-wait page
-        'promptDir': 'Prompts/',  # directory containing prompts and questions files
-        'promptFile': 'GoNoGoPrompts.txt',  # Name of text file containing prompts
+        "skipPrompts": False,  # go right to the scanner-wait page
+        "promptDir": "Prompts/",  # directory containing prompts and questions files
+        "promptFile": "GoNoGoPrompts.txt",  # Name of text file containing prompts
         # declare display parameters
-        'fullScreen': True,       # run in full screen mode?
+        "fullScreen": True,  # run in full screen mode?
         # display on primary screen (0) or secondary (1)?
-        'screenToShow': 0,
-        'fixCrossSize': 60,       # size of cross, in pixels
+        "screenToShow": 0,
+        "fixCrossSize": 60,  # size of cross, in pixels
         # (x,y) pos of fixation cross displayed before each stimulus (for gaze drift correction)
-        'fixCrossPos': [0, 0],
+        "fixCrossPos": [0, 0],
         # in rgb255 space: (r,g,b) all between 0 and 255
-        'screenColor': (128, 128, 128)
+        "screenColor": (128, 128, 128),
     }
 
-    n_trials = int((duration - params['tStartup'] -
-                    params['tCoolDown']) / (params['ISI'] + params['stimDur']))
+    n_trials = int(
+        (duration - params["tStartup"] - params["tCoolDown"])
+        / (params["ISI"] + params["stimDur"])
+    )
 
     screenRes = [800, 600]
 
     # create clocks and window
     globalClock = core.Clock()  # to keep track of time
     trialClock = core.Clock()  # to keep track of time
-    win = visual.Window(screenRes, fullscr=params['fullScreen'], allowGUI=False, monitor='testMonitor',
-                        screen=params['screenToShow'], units='deg', name='win', color=params['screenColor'], colorSpace='rgb255')
+    win = visual.Window(
+        screenRes,
+        fullscr=params["fullScreen"],
+        allowGUI=False,
+        monitor="testMonitor",
+        screen=params["screenToShow"],
+        units="deg",
+        name="win",
+        color=params["screenColor"],
+        colorSpace="rgb255",
+    )
     # create fixation cross
-    fCS = params['fixCrossSize']  # size (for brevity)
-    fCP = params['fixCrossPos']  # position (for brevity)
-    fixation = visual.ShapeStim(win, lineColor='#000000', lineWidth=3.0, vertices=(
-        (fCP[0]-fCS/2, fCP[1]), (fCP[0]+fCS/2, fCP[1]), (fCP[0], fCP[1]), (fCP[0], fCP[1]+fCS/2), (fCP[0], fCP[1]-fCS/2)), units='pix', closeShape=False, name='fixCross')
+    fCS = params["fixCrossSize"]  # size (for brevity)
+    fCP = params["fixCrossPos"]  # position (for brevity)
+    fixation = visual.ShapeStim(
+        win,
+        lineColor="#000000",
+        lineWidth=3.0,
+        vertices=(
+            (fCP[0] - fCS / 2, fCP[1]),
+            (fCP[0] + fCS / 2, fCP[1]),
+            (fCP[0], fCP[1]),
+            (fCP[0], fCP[1] + fCS / 2),
+            (fCP[0], fCP[1] - fCS / 2),
+        ),
+        units="pix",
+        closeShape=False,
+        name="fixCross",
+    )
     # create text stimuli
-    message1 = visual.TextStim(win, pos=[0, +.5], wrapWidth=1.5, color='#000000',
-                               alignHoriz='center', name='topMsg', text="aaa", units='norm')
-    message2 = visual.TextStim(win, pos=[0, 0], wrapWidth=1.5, color='#000000',
-                               alignHoriz='center', name='middleMsg', text="bbb", units='norm')
-    message3 = visual.TextStim(win, pos=[0, -.5], wrapWidth=1.5, color='#000000',
-                               alignHoriz='center', name='bottomMsg', text="bbb", units='norm')
+    message1 = visual.TextStim(
+        win,
+        pos=[0, +0.5],
+        wrapWidth=1.5,
+        color="#000000",
+        alignHoriz="center",
+        name="topMsg",
+        text="aaa",
+        units="norm",
+    )
+    message2 = visual.TextStim(
+        win,
+        pos=[0, 0],
+        wrapWidth=1.5,
+        color="#000000",
+        alignHoriz="center",
+        name="middleMsg",
+        text="bbb",
+        units="norm",
+    )
+    message3 = visual.TextStim(
+        win,
+        pos=[0, -0.5],
+        wrapWidth=1.5,
+        color="#000000",
+        alignHoriz="center",
+        name="bottomMsg",
+        text="bbb",
+        units="norm",
+    )
 
     # draw stimuli
-    fCS_rt2 = fCS/math.sqrt(2)
-    stims = {'square': [], 'diamond': [], 'circle': []}
-    stims['square'] = visual.ShapeStim(win, lineColor='#000000', lineWidth=3.0, vertices=((fCP[0]-fCS/2, fCP[1]-fCS/2), (fCP[0]+fCS/2, fCP[1]-fCS/2),
-                                                                                          (fCP[0]+fCS/2, fCP[1]+fCS/2), (fCP[0]-fCS/2, fCP[1]+fCS/2), (fCP[0]-fCS/2, fCP[1]-fCS/2)), units='pix', closeShape=False, name='square')
-    stims['diamond'] = visual.ShapeStim(win, lineColor='#000000', lineWidth=3.0, vertices=((fCP[0], fCP[1]-fCS_rt2), (fCP[0]-fCS_rt2, fCP[1]),
-                                                                                           (fCP[0], fCP[1]+fCS_rt2), (fCP[0]+fCS_rt2, fCP[1]), (fCP[0], fCP[1]-fCS_rt2)), units='pix', closeShape=False, name='diamond')
-    stims['circle'] = visual.Circle(
-        win, lineColor='#000000', lineWidth=3.0, radius=fCS_rt2, edges=32, units='pix')
+    fCS_rt2 = fCS / math.sqrt(2)
+    stims = {"square": [], "diamond": [], "circle": []}
+    stims["square"] = visual.ShapeStim(
+        win,
+        lineColor="#000000",
+        lineWidth=3.0,
+        vertices=(
+            (fCP[0] - fCS / 2, fCP[1] - fCS / 2),
+            (fCP[0] + fCS / 2, fCP[1] - fCS / 2),
+            (fCP[0] + fCS / 2, fCP[1] + fCS / 2),
+            (fCP[0] - fCS / 2, fCP[1] + fCS / 2),
+            (fCP[0] - fCS / 2, fCP[1] - fCS / 2),
+        ),
+        units="pix",
+        closeShape=False,
+        name="square",
+    )
+    stims["diamond"] = visual.ShapeStim(
+        win,
+        lineColor="#000000",
+        lineWidth=3.0,
+        vertices=(
+            (fCP[0], fCP[1] - fCS_rt2),
+            (fCP[0] - fCS_rt2, fCP[1]),
+            (fCP[0], fCP[1] + fCS_rt2),
+            (fCP[0] + fCS_rt2, fCP[1]),
+            (fCP[0], fCP[1] - fCS_rt2),
+        ),
+        units="pix",
+        closeShape=False,
+        name="diamond",
+    )
+    stims["circle"] = visual.Circle(
+        win, lineColor="#000000", lineWidth=3.0, radius=fCS_rt2, edges=32, units="pix"
+    )
 
     tNextFlip = [0.0]
 
@@ -126,43 +202,49 @@ def present(subject, session, duration=120):
     for iTrial in range(0, n_trials):
 
         # Decide Trial Params
-        isGoTrial = random.random() < params['goStimProb']
+        isGoTrial = random.random() < params["goStimProb"]
 
         # display info to experimenter
-        print(('Running Trial %d: isGo = %d, ISI = %.1f' %
-               (iTrial, isGoTrial, params['ISI'])))
+        print(
+            (
+                "Running Trial %d: isGo = %d, ISI = %.1f"
+                % (iTrial, isGoTrial, params["ISI"])
+            )
+        )
 
         if iTrial == 0:
             AddToFlipTime(2)
         fixation.draw()
-        while (globalClock.getTime() < tNextFlip[0]):
+        while globalClock.getTime() < tNextFlip[0]:
             pass
         win.flip()
         tStimStart = globalClock.getTime()  # record time when window flipped
         # set up next win flip time after this one
-        AddToFlipTime(params['ISI'])  # add to tNextFlip[0]
+        AddToFlipTime(params["ISI"])  # add to tNextFlip[0]
 
         # Draw stim
         if isGoTrial:
-            stims[params['goStim']].draw()
-            win.logOnFlip(level=logging.EXP, msg='Display go stim (%s)' %
-                          params['goStim'])
+            stims[params["goStim"]].draw()
+            win.logOnFlip(
+                level=logging.EXP, msg="Display go stim (%s)" % params["goStim"]
+            )
             timestamp = time()
             outlet.push_sample([markernames[0]], timestamp)
         else:
-            stims[params['noGoStim']].draw()
-            win.logOnFlip(level=logging.EXP,
-                          msg='Display no-go stim (%s)' % params['noGoStim'])
+            stims[params["noGoStim"]].draw()
+            win.logOnFlip(
+                level=logging.EXP, msg="Display no-go stim (%s)" % params["noGoStim"]
+            )
             timestamp = time()
             outlet.push_sample([markernames[1]], timestamp)
         # Wait until it's time to display
-        while (globalClock.getTime() < tNextFlip[0]):
+        while globalClock.getTime() < tNextFlip[0]:
             pass
         # log & flip window to display image
         win.flip()
         tStimStart = globalClock.getTime()  # record time when window flipped
         # set up next win flip time after this one
-        AddToFlipTime(params['stimDur'])  # add to tNextFlip[0]
+        AddToFlipTime(params["stimDur"])  # add to tNextFlip[0]
 
         # Flush the key buffer and mouse movements
         event.clearEvents()
@@ -171,21 +253,21 @@ def present(subject, session, duration=120):
         thisKey = None
         t = None
         # until it's time for the next frame
-        while (globalClock.getTime() < tNextFlip[0]):
+        while globalClock.getTime() < tNextFlip[0]:
             # get new keys
-            #newKeys = event.getKeys(keyList=params['respKeys']+['q','escape'],timeStamped=globalClock)
+            # newKeys = event.getKeys(keyList=params['respKeys']+['q','escape'],timeStamped=globalClock)
             newKeys = event.getKeys(timeStamped=globalClock)
             # check each keypress for escape or response keys
             if len(newKeys) > 0:
                 for thisKey in newKeys:
                     respKey = thisKey[0]
                     t = globalClock.getTime() - tStimStart
-                    #tempArray = [iTrial, isGoTrial, respKey[0]]
+                    # tempArray = [iTrial, isGoTrial, respKey[0]]
                     # responses.append(tempArray)
-                    if thisKey[0] in ['q', 'escape']:  # escape keys
+                    if thisKey[0] in ["q", "escape"]:  # escape keys
                         CoolDown()  # exit gracefully
                     # only take first keypress
-                    elif thisKey[0] in params['respKeys'] and respKey == None:
+                    elif thisKey[0] in params["respKeys"] and respKey == None:
                         respKey = thisKey  # record keypress
 
         tempArray = [iTrial, isGoTrial, respKey, t]
@@ -196,7 +278,7 @@ def present(subject, session, duration=120):
             count_nogo += 1
 
         if isGoTrial:
-            if respKey == 'space':
+            if respKey == "space":
                 hits_go += 1
             else:
                 fa_go += 1
@@ -207,65 +289,93 @@ def present(subject, session, duration=120):
                 fa_nogo += 1
 
         # get RT for correct go trials
-        if isGoTrial and respKey == 'space':
+        if isGoTrial and respKey == "space":
             rt[iTrial] = t
         else:
             rt[iTrial] = np.nan
 
         # Display the fixation cross
-        if params['ISI'] > 0:  # if there should be a fixation cross
+        if params["ISI"] > 0:  # if there should be a fixation cross
             fixation.draw()  # draw it
-            win.logOnFlip(level=logging.EXP, msg='Display Fixation')
+            win.logOnFlip(level=logging.EXP, msg="Display Fixation")
             win.flip()
 
         # return
         if iTrial == n_trials:
-            AddToFlipTime(params['tCoolDown'])
+            AddToFlipTime(params["tCoolDown"])
 
     fixation.draw()
     win.flip()
-    while (globalClock.getTime() < tNextFlip[0]):
+    while globalClock.getTime() < tNextFlip[0]:
         pass
 
     acc_go = np.round(float(hits_go) / float(count_go) * float(100), 2)
     acc_nogo = np.round(float(hits_nogo) / float(count_nogo) * float(100), 2)
     mean_rt = np.round(float(np.nanmean(rt)), 2)
 
-    outname = outdir + 'behav_' + subject + \
-        '_run' + str(session) + '.mat'
-    scipy.io.savemat(outname, {'rt': rt, 'mean_rt': mean_rt, 'acc_go': acc_go, 'acc_nogo': acc_nogo, 'hits_go': hits_go,
-                               'hits_nogo': hits_nogo, 'fa_go': fa_go, 'fa_nogo': fa_nogo, 'count_go': count_go, 'count_nogo': count_nogo})
+    outname = outdir + "behav_" + subject + "_run" + str(session) + ".mat"
+    scipy.io.savemat(
+        outname,
+        {
+            "rt": rt,
+            "mean_rt": mean_rt,
+            "acc_go": acc_go,
+            "acc_nogo": acc_nogo,
+            "hits_go": hits_go,
+            "hits_nogo": hits_nogo,
+            "fa_go": fa_go,
+            "fa_nogo": fa_nogo,
+            "count_go": count_go,
+            "count_nogo": count_nogo,
+        },
+    )
 
     # display results
     message1.setText("That's the end! Here are your results:")
-    message2.setText('N trials = %d \nGo accuracy = %d/%d (%0.2f) \nNoGo accuracy = %d/%d (%0.2f) \nMean correct Go RT = %0.2f' %
-                     (params['nTrials'], hits_go, count_go, round(acc_go, 2), hits_nogo, count_nogo, round(acc_nogo, 2), round(mean_rt, 2)))
+    message2.setText(
+        "N trials = %d \nGo accuracy = %d/%d (%0.2f) \nNoGo accuracy = %d/%d (%0.2f) \nMean correct Go RT = %0.2f"
+        % (
+            params["nTrials"],
+            hits_go,
+            count_go,
+            round(acc_go, 2),
+            hits_nogo,
+            count_nogo,
+            round(acc_nogo, 2),
+            round(mean_rt, 2),
+        )
+    )
     message3.setText("Press 'q' or 'escape' to end the session.")
-    win.logOnFlip(level=logging.EXP, msg='Display TheEnd')
+    win.logOnFlip(level=logging.EXP, msg="Display TheEnd")
     message1.draw()
     message2.draw()
     message3.draw()
     win.flip()
-    thisKey = event.waitKeys(keyList=['q', 'escape'])
+    thisKey = event.waitKeys(keyList=["q", "escape"])
     core.quit()
     mywin.close()
 
 
 def main():
     parser = OptionParser()
-    parser.add_option("-s", "--subject",
-                      dest="subject", type='string',
-                      help="name of subject.")
-    parser.add_option("-n", "--session",
-                      dest="session", type='int',
-                      help="number of session.")
-    parser.add_option("-d", "--duration",
-                      dest="duration", type='int', default=120,
-                      help="duration of the recording in seconds.")
+    parser.add_option(
+        "-s", "--subject", dest="subject", type="string", help="name of subject."
+    )
+    parser.add_option(
+        "-n", "--session", dest="session", type="int", help="number of session."
+    )
+    parser.add_option(
+        "-d",
+        "--duration",
+        dest="duration",
+        type="int",
+        default=120,
+        help="duration of the recording in seconds.",
+    )
 
     (options, args) = parser.parse_args()
     present(options.subject, options.session, options.duration)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -29,12 +29,11 @@ def present(duration=120, eeg=None, save_fn=None):
 
     # start the EEG stream, will delay 5 seconds to let signal settle
 
-
     # Setup graphics
-    mywin = visual.Window([1600, 900], monitor='testMonitor', units="deg", fullscr=True)
+    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
 
-    faces = list(map(load_image, glob(os.path.join(FACE_HOUSE, 'faces', '*_3.jpg'))))
-    houses = list(map(load_image, glob(os.path.join(FACE_HOUSE, 'houses', '*.3.jpg'))))
+    faces = list(map(load_image, glob(os.path.join(FACE_HOUSE, "faces", "*_3.jpg"))))
+    houses = list(map(load_image, glob(os.path.join(FACE_HOUSE, "houses", "*.3.jpg"))))
     stim = [houses, faces]
 
     # Show the instructions screen
@@ -42,9 +41,11 @@ def present(duration=120, eeg=None, save_fn=None):
 
     if eeg:
         if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
-            save_fn = generate_save_fn(eeg.device_name, 'visual_n170', 'unnamed')
-            print(f'No path for a save file was passed to the experiment. Saving data to {save_fn}')
-        eeg.start(save_fn, duration=record_duration+5)
+            save_fn = generate_save_fn(eeg.device_name, "visual_n170", "unnamed")
+            print(
+                f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
+            )
+        eeg.start(save_fn, duration=record_duration + 5)
 
     # Start EEG Stream, wait for signal to settle, and then pull timestamp for start point
     start = time()
@@ -55,19 +56,19 @@ def present(duration=120, eeg=None, save_fn=None):
         core.wait(iti + np.random.rand() * jitter)
 
         # Select and display image
-        label = trials['image_type'].iloc[ii]
+        label = trials["image_type"].iloc[ii]
         image = choice(faces if label == 1 else houses)
         image.draw()
 
         # Push sample
-        if eeg: 
+        if eeg:
             timestamp = time()
-            if eeg.backend == 'muselsl':
+            if eeg.backend == "muselsl":
                 marker = [markernames[label]]
             else:
                 marker = markernames[label]
             eeg.push_sample(marker=marker, timestamp=timestamp)
-    
+
         mywin.flip()
 
         # offset
@@ -79,17 +80,15 @@ def present(duration=120, eeg=None, save_fn=None):
         event.clearEvents()
 
     # Cleanup
-    if eeg: eeg.stop()
+    if eeg:
+        eeg.stop()
 
     mywin.close()
 
 
-
-
 def show_instructions(duration):
 
-    instruction_text = \
-    """
+    instruction_text = """
     Welcome to the N170 experiment! 
  
     Stay still, focus on the centre of the screen, and try not to blink. 
@@ -99,19 +98,15 @@ def show_instructions(duration):
     Press spacebar to continue. 
     
     """
-    instruction_text = instruction_text %duration
+    instruction_text = instruction_text % duration
 
     # graphics
-    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg",
-                          fullscr=True)
+    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
 
     mywin.mouseVisible = False
 
-    #Instructions
-    text = visual.TextStim(
-        win=mywin,
-        text=instruction_text,
-        color=[-1, -1, -1])
+    # Instructions
+    text = visual.TextStim(win=mywin, text=instruction_text, color=[-1, -1, -1])
     text.draw()
     mywin.flip()
     event.waitKeys(keyList="space")

--- a/eegnb/experiments/visual_n170/n170_fixedstimorder.py
+++ b/eegnb/experiments/visual_n170/n170_fixedstimorder.py
@@ -13,82 +13,81 @@ from glob import glob
 from random import choice
 
 import numpy as np
-from pandas import DataFrame,read_csv
+from pandas import DataFrame, read_csv
 from psychopy import visual, core, event
 from pylsl import StreamInfo, StreamOutlet
 
-from eegnb import stimuli,experiments
+from eegnb import stimuli, experiments
+
 stim_dir = os.path.split(stimuli.__file__)[0]
 exp_dir = os.path.split(experiments.__file__)[0]
 
 # fixed stim order list file
-fso_list_file = os.path.join(exp_dir, 'visual_n170', 'n170_fixedstimorder_list.csv')
+fso_list_file = os.path.join(exp_dir, "visual_n170", "n170_fixedstimorder_list.csv")
 
 
 def present(duration=120):
 
     # Create markers stream outlet
-    #info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
-    info = StreamInfo('Markers', 'Markers', 3, 0, 'int32', 'myuidw43536')
+    # info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+    info = StreamInfo("Markers", "Markers", 3, 0, "int32", "myuidw43536")
     outlet = StreamOutlet(info)
 
-    #markernames = [1, 2]
+    # markernames = [1, 2]
     start = time()
 
     # Set up trial parameters
-    #n_trials = 2010
+    # n_trials = 2010
     iti = 0.8
     soa = 0.2
     jitter = 0.2
     record_duration = np.float32(duration)
 
     # Setup trial list
-    #image_type = np.random.binomial(1, 0.5, n_trials)
-    #trials = DataFrame(dict(image_type=image_type,
+    # image_type = np.random.binomial(1, 0.5, n_trials)
+    # trials = DataFrame(dict(image_type=image_type,
     #                        timestamp=np.zeros(n_trials)))
 
-    
     fso_ims = read_csv(fso_list_file)
     n_trials = fso_ims.shape[0]
-    
-    
+
     # Setup graphics
 
     def load_image(filename):
         return visual.ImageStim(win=mywin, image=filename)
 
-    mywin = visual.Window([1600, 900], monitor='testMonitor', units='deg', winType='pygame',
-                          fullscr=True)
-    
-    #faces = list(map(load_image, glob(
+    mywin = visual.Window(
+        [1600, 900], monitor="testMonitor", units="deg", winType="pygame", fullscr=True
+    )
+
+    # faces = list(map(load_image, glob(
     #    'stimulus_presentation/stim/face_house/faces/*_3.jpg')))
-    #houses = list(map(load_image, glob(
+    # houses = list(map(load_image, glob(
     #    'stimulus_presentation/stim/face_house/houses/*.3.jpg')))
-    
 
-    #for ii, trial in trials.iterrows():
-    for ii,trial in fso_ims.iterrows():
+    # for ii, trial in trials.iterrows():
+    for ii, trial in fso_ims.iterrows():
 
-        trialnum,filename,facehouse,girlboy = trial.values
-        filename = os.path.join(stim_dir, filename)        
+        trialnum, filename, facehouse, girlboy = trial.values
+        filename = os.path.join(stim_dir, filename)
 
         # Intertrial interval
         core.wait(iti + np.random.rand() * jitter)
-    
+
         # Select and display image
-        #label = trials['image_type'].iloc[ii]
-        #image = choice(faces if label == 1 else houses)
+        # label = trials['image_type'].iloc[ii]
+        # image = choice(faces if label == 1 else houses)
         image = load_image(filename)
-        
+
         image.draw()
-     
+
         # Send marker
         timestamp = time()
-        #outlet.push_sample([markernames[label]], timestamp)
-        outlet.push_sample([trialnum,facehouse+1,girlboy+1], timestamp)
-        
+        # outlet.push_sample([markernames[label]], timestamp)
+        outlet.push_sample([trialnum, facehouse + 1, girlboy + 1], timestamp)
+
         mywin.flip()
-    
+
         # offset
         core.wait(soa)
         mywin.flip()
@@ -103,13 +102,18 @@ def present(duration=120):
 def main():
     parser = OptionParser()
 
-    parser.add_option("-d", "--duration",
-                      dest="duration", type='int', default=120,
-                      help="duration of the recording in seconds.")
+    parser.add_option(
+        "-d",
+        "--duration",
+        dest="duration",
+        type="int",
+        default=120,
+        help="duration of the recording in seconds.",
+    )
 
     (options, args) = parser.parse_args()
     present(options.duration)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/experiments/visual_n170/n170_old.py
+++ b/eegnb/experiments/visual_n170/n170_old.py
@@ -20,13 +20,14 @@ from pylsl import StreamInfo, StreamOutlet
 from eegnb import stimuli
 
 stim_dir = os.path.split(stimuli.__file__)[0]
-faces_dir = os.path.join(stim_dir, 'visual', 'face_house', 'faces')
-houses_dir = os.path.join(stim_dir, 'visual', 'face_house', 'houses')
+faces_dir = os.path.join(stim_dir, "visual", "face_house", "faces")
+houses_dir = os.path.join(stim_dir, "visual", "face_house", "houses")
+
 
 def present(duration=120):
 
     # Create markers stream outlet
-    info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+    info = StreamInfo("Markers", "Markers", 1, 0, "int32", "myuidw43536")
     outlet = StreamOutlet(info)
 
     markernames = [1, 2]
@@ -41,29 +42,29 @@ def present(duration=120):
 
     # Setup trial list
     image_type = np.random.binomial(1, 0.5, n_trials)
-    trials = DataFrame(dict(image_type=image_type,
-                            timestamp=np.zeros(n_trials)))
+    trials = DataFrame(dict(image_type=image_type, timestamp=np.zeros(n_trials)))
 
     # Setup graphics
 
     def load_image(filename):
         return visual.ImageStim(win=mywin, image=filename)
 
-    mywin = visual.Window([1600, 900], monitor='testMonitor', units='deg', winType='pygame',
-                          fullscr=True)
-    #faces = list(map(load_image, glob(
+    mywin = visual.Window(
+        [1600, 900], monitor="testMonitor", units="deg", winType="pygame", fullscr=True
+    )
+    # faces = list(map(load_image, glob(
     #    'stimulus_presentation/stim/face_house/faces/*_3.jpg')))
-    faces = list(map(load_image, glob(faces_dir + '/*_3.jpg')))
-    #houses = list(map(load_image, glob(
-    #    'stimulus_presentation/stim/face_house/houses/*.3.jpg'))) 
-    houses = list(map(load_image, glob(houses_dir + '/*.3.jpg')))
+    faces = list(map(load_image, glob(faces_dir + "/*_3.jpg")))
+    # houses = list(map(load_image, glob(
+    #    'stimulus_presentation/stim/face_house/houses/*.3.jpg')))
+    houses = list(map(load_image, glob(houses_dir + "/*.3.jpg")))
 
     for ii, trial in trials.iterrows():
         # Intertrial interval
         core.wait(iti + np.random.rand() * jitter)
 
         # Select and display image
-        label = trials['image_type'].iloc[ii]
+        label = trials["image_type"].iloc[ii]
         image = choice(faces if label == 1 else houses)
         image.draw()
 
@@ -86,13 +87,18 @@ def present(duration=120):
 def main():
     parser = OptionParser()
 
-    parser.add_option("-d", "--duration",
-                      dest="duration", type='int', default=120,
-                      help="duration of the recording in seconds.")
+    parser.add_option(
+        "-d",
+        "--duration",
+        dest="duration",
+        type="int",
+        default=120,
+        help="duration of the recording in seconds.",
+    )
 
     (options, args) = parser.parse_args()
     present(options.duration)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/experiments/visual_p300/p300.py
+++ b/eegnb/experiments/visual_p300/p300.py
@@ -27,10 +27,10 @@ def present(duration=120, eeg=None, save_fn=None):
         return visual.ImageStim(win=mywin, image=fn)
 
     # Setup graphics
-    mywin = visual.Window([1600, 900], monitor='testMonitor', units="deg", fullscr=True)
+    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
 
-    targets = list(map(load_image, glob(os.path.join(CAT_DOG, 'target-*.jpg'))))
-    nontargets = list(map(load_image, glob(os.path.join(CAT_DOG, 'nontarget-*.jpg'))))
+    targets = list(map(load_image, glob(os.path.join(CAT_DOG, "target-*.jpg"))))
+    nontargets = list(map(load_image, glob(os.path.join(CAT_DOG, "nontarget-*.jpg"))))
     stim = [nontargets, targets]
 
     # Show instructions
@@ -39,8 +39,10 @@ def present(duration=120, eeg=None, save_fn=None):
     # start the EEG stream, will delay 5 seconds to let signal settle
     if eeg:
         if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
-            save_fn = generate_save_fn(eeg.device_name, 'visual_p300', 'unnamed')
-            print(f'No path for a save file was passed to the experiment. Saving data to {save_fn}')
+            save_fn = generate_save_fn(eeg.device_name, "visual_p300", "unnamed")
+            print(
+                f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
+            )
         eeg.start(save_fn, duration=record_duration)
 
     # Iterate through the events
@@ -50,19 +52,18 @@ def present(duration=120, eeg=None, save_fn=None):
         core.wait(iti + np.random.rand() * jitter)
 
         # Select and display image
-        label = trials['image_type'].iloc[ii]
+        label = trials["image_type"].iloc[ii]
         image = choice(targets if label == 1 else nontargets)
         image.draw()
 
         # Push sample
         if eeg:
             timestamp = time()
-            if eeg.backend == 'muselsl':
+            if eeg.backend == "muselsl":
                 marker = [markernames[label]]
             else:
                 marker = markernames[label]
             eeg.push_sample(marker=marker, timestamp=timestamp)
-
 
         mywin.flip()
 
@@ -75,16 +76,14 @@ def present(duration=120, eeg=None, save_fn=None):
         event.clearEvents()
 
     # Cleanup
-    if eeg: eeg.stop()
+    if eeg:
+        eeg.stop()
     mywin.close()
-
-
 
 
 def show_instructions(duration):
 
-    instruction_text = \
-    """
+    instruction_text = """
     Welcome to the P300 experiment! 
  
     Stay still, focus on the centre of the screen, and try not to blink. 
@@ -94,23 +93,18 @@ def show_instructions(duration):
     Press spacebar to continue. 
     
     """
-    instruction_text = instruction_text %duration
+    instruction_text = instruction_text % duration
 
     # graphics
-    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg",
-                          fullscr=True)
+    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
 
     mywin.mouseVisible = False
 
-    #Instructions
-    text = visual.TextStim(
-        win=mywin,
-        text=instruction_text,
-        color=[-1, -1, -1])
+    # Instructions
+    text = visual.TextStim(win=mywin, text=instruction_text, color=[-1, -1, -1])
     text.draw()
     mywin.flip()
     event.waitKeys(keyList="space")
 
     mywin.mouseVisible = True
     mywin.close()
-

--- a/eegnb/experiments/visual_p300/p300_stripes.py
+++ b/eegnb/experiments/visual_p300/p300_stripes.py
@@ -6,10 +6,10 @@ from optparse import OptionParser
 from pylsl import StreamInfo, StreamOutlet
 
 
-def present(duration,subject,run):
+def present(duration, subject, run):
 
     # create
-    info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+    info = StreamInfo("Markers", "Markers", 1, 0, "int32", "myuidw43536")
 
     # next make an outlet
     outlet = StreamOutlet(info)
@@ -19,7 +19,7 @@ def present(duration,subject,run):
     start = time()
 
     n_trials = 2010
-    iti = .4
+    iti = 0.4
     soa = 0.3
     jitter = 0.2
     record_duration = np.float32(duration)
@@ -27,15 +27,14 @@ def present(duration,subject,run):
     # Setup log
     position = np.random.binomial(1, 0.15, n_trials)
 
-    trials = DataFrame(dict(position=position,
-                            timestamp=np.zeros(n_trials)))
+    trials = DataFrame(dict(position=position, timestamp=np.zeros(n_trials)))
 
     # graphics
-    mywin = visual.Window([1920, 1080], monitor="testMonitor", units="deg",
-                          fullscr=True)
-    grating = visual.GratingStim(win=mywin, mask='gauss', size=40, sf=2)
-    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0,
-                                  rgb=[1, 0, 0])
+    mywin = visual.Window(
+        [1920, 1080], monitor="testMonitor", units="deg", fullscr=True
+    )
+    grating = visual.GratingStim(win=mywin, mask="gauss", size=40, sf=2)
+    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0, rgb=[1, 0, 0])
 
     for ii, trial in trials.iterrows():
         # inter trial interval
@@ -43,7 +42,7 @@ def present(duration,subject,run):
 
         # onset
         grating.phase += np.random.rand()
-        pos = trials['position'].iloc[ii]
+        pos = trials["position"].iloc[ii]
         grating.ori = 90 * pos
         grating.draw()
         fixation.draw()
@@ -65,15 +64,30 @@ def present(duration,subject,run):
 def main():
     parser = OptionParser()
 
-    parser.add_option("-d", "--duration",
-                      dest="duration", type='int', default=120,
-                      help="duration of the recording in seconds.")
-    parser.add_option("-s", "--subject",
-                  dest="subject", type='int', default=1,
-                  help="subject number: must be an integer")
-    parser.add_option("-r", "--run",
-                  dest="run", type='int', default=1,
-                  help="run (session) number: must be an integer")
+    parser.add_option(
+        "-d",
+        "--duration",
+        dest="duration",
+        type="int",
+        default=120,
+        help="duration of the recording in seconds.",
+    )
+    parser.add_option(
+        "-s",
+        "--subject",
+        dest="subject",
+        type="int",
+        default=1,
+        help="subject number: must be an integer",
+    )
+    parser.add_option(
+        "-r",
+        "--run",
+        dest="run",
+        type="int",
+        default=1,
+        help="run (session) number: must be an integer",
+    )
 
     (options, args) = parser.parse_args()
     present(options.duration)
@@ -81,5 +95,5 @@ def main():
     present(options.n)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/experiments/visual_ssvep/ssvep.py
+++ b/eegnb/experiments/visual_ssvep/ssvep.py
@@ -23,17 +23,17 @@ def present(duration=120, eeg=None, save_fn=None):
     trials = DataFrame(dict(stim_freq=stim_freq, timestamp=np.zeros(n_trials)))
 
     # Set up graphics
-    mywin = visual.Window([1600, 900], monitor='testMonitor', units="deg", fullscr=True)
-    grating = visual.GratingStim(
-        win=mywin, mask='circle', size=80, sf=0.2)
+    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
+    grating = visual.GratingStim(win=mywin, mask="circle", size=80, sf=0.2)
     grating_neg = visual.GratingStim(
-        win=mywin, mask='circle', size=80, sf=0.2, phase=0.5)
+        win=mywin, mask="circle", size=80, sf=0.2, phase=0.5
+    )
     fixation = visual.GratingStim(
-        win=mywin, size=0.2, pos=[0, 0], sf=0.2, color=[1, 0, 0], autoDraw=True)
-
+        win=mywin, size=0.2, pos=[0, 0], sf=0.2, color=[1, 0, 0], autoDraw=True
+    )
 
     # Generate the possible ssvep frequencies based on monitor refresh rate
-    def get_possible_ssvep_freqs(frame_rate, stim_type='single'):
+    def get_possible_ssvep_freqs(frame_rate, stim_type="single"):
         """Get possible SSVEP stimulation frequencies.
         Utility function that returns the possible SSVEP stimulation
         frequencies and on/off pattern based on screen refresh rate.
@@ -59,7 +59,7 @@ def present(duration=120, eeg=None, save_fn=None):
         max_period_nb = int(frame_rate / 6)
         periods = np.arange(max_period_nb) + 1
 
-        if stim_type == 'single':
+        if stim_type == "single":
             freqs = dict()
             for p1 in periods:
                 for p2 in periods:
@@ -68,7 +68,7 @@ def present(duration=120, eeg=None, save_fn=None):
                         freqs[f].append((p1, p2))
                     except:
                         freqs[f] = [(p1, p2)]
-        elif stim_type == 'reversal':
+        elif stim_type == "reversal":
             freqs = {frame_rate / p: [(p, p)] for p in periods[::-1]}
 
         return freqs
@@ -101,18 +101,23 @@ def present(duration=120, eeg=None, save_fn=None):
             cycle = (cycle, cycle)
             n_cycles = int(soa * stim_freq) / 2
 
-        return {'cycle': cycle,
-                'freq': stim_freq,
-                'n_cycles': n_cycles}
+        return {"cycle": cycle, "freq": stim_freq, "n_cycles": n_cycles}
 
     # Set up stimuli
-    frame_rate = np.round(mywin.getActualFrameRate()) # Frame rate, in Hz
-    freqs = get_possible_ssvep_freqs(frame_rate, stim_type='reversal')
-    stim_patterns = [init_flicker_stim(frame_rate, 2, soa),
-                     init_flicker_stim(frame_rate, 3, soa)]
+    frame_rate = np.round(mywin.getActualFrameRate())  # Frame rate, in Hz
+    freqs = get_possible_ssvep_freqs(frame_rate, stim_type="reversal")
+    stim_patterns = [
+        init_flicker_stim(frame_rate, 2, soa),
+        init_flicker_stim(frame_rate, 3, soa),
+    ]
 
-    print(('Flickering frequencies (Hz): {}\n'.format(
-        [stim_patterns[0]['freq'], stim_patterns[1]['freq']])))
+    print(
+        (
+            "Flickering frequencies (Hz): {}\n".format(
+                [stim_patterns[0]["freq"], stim_patterns[1]["freq"]]
+            )
+        )
+    )
 
     # Show the instructions screen
     show_instructions(duration)
@@ -120,8 +125,10 @@ def present(duration=120, eeg=None, save_fn=None):
     # start the EEG stream, will delay 5 seconds to let signal settle
     if eeg:
         if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
-            save_fn = generate_save_fn(eeg.device_name, 'visual_ssvep', 'unnamed')
-            print(f'No path for a save file was passed to the experiment. Saving data to {save_fn}')
+            save_fn = generate_save_fn(eeg.device_name, "visual_ssvep", "unnamed")
+            print(
+                f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
+            )
         eeg.start(save_fn, duration=record_duration)
 
     # Iterate through trials
@@ -131,25 +138,25 @@ def present(duration=120, eeg=None, save_fn=None):
         core.wait(iti + np.random.rand() * jitter)
 
         # Select stimulus frequency
-        ind = trials['stim_freq'].iloc[ii]
+        ind = trials["stim_freq"].iloc[ii]
 
         # Push sample
         if eeg:
             timestamp = time()
-            if eeg.backend == 'muselsl':
+            if eeg.backend == "muselsl":
                 marker = [markernames[ind]]
             else:
                 marker = markernames[ind]
             eeg.push_sample(marker=marker, timestamp=timestamp)
 
         # Present flickering stim
-        for _ in range(int(stim_patterns[ind]['n_cycles'])):
+        for _ in range(int(stim_patterns[ind]["n_cycles"])):
             grating.setAutoDraw(True)
-            for _ in range(int(stim_patterns[ind]['cycle'][0])):
+            for _ in range(int(stim_patterns[ind]["cycle"][0])):
                 mywin.flip()
             grating.setAutoDraw(False)
             grating_neg.setAutoDraw(True)
-            for _ in range(stim_patterns[ind]['cycle'][1]):
+            for _ in range(stim_patterns[ind]["cycle"][1]):
                 mywin.flip()
             grating_neg.setAutoDraw(False)
 
@@ -160,16 +167,14 @@ def present(duration=120, eeg=None, save_fn=None):
         event.clearEvents()
 
     # Cleanup
-    if eeg: eeg.stop()
+    if eeg:
+        eeg.stop()
     mywin.close()
-
-
 
 
 def show_instructions(duration):
 
-    instruction_text = \
-    """
+    instruction_text = """
     Welcome to the SSVEP experiment! 
  
     Stay still, focus on the centre of the screen, and try not to blink. 
@@ -181,19 +186,15 @@ def show_instructions(duration):
     Warning: This experiment contains flashing lights and may induce a seizure. Discretion is advised.
     
     """
-    instruction_text = instruction_text %duration
+    instruction_text = instruction_text % duration
 
     # graphics
-    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg",
-                          fullscr=True)
+    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
 
     mywin.mouseVisible = False
 
-    #Instructions
-    text = visual.TextStim(
-        win=mywin,
-        text=instruction_text,
-        color=[-1, -1, -1])
+    # Instructions
+    text = visual.TextStim(win=mywin, text=instruction_text, color=[-1, -1, -1])
     text.draw()
     mywin.flip()
     event.waitKeys(keyList="space")

--- a/eegnb/experiments/visual_vep/vep.py
+++ b/eegnb/experiments/visual_vep/vep.py
@@ -9,7 +9,7 @@ from pylsl import StreamInfo, StreamOutlet
 def present(duration=120):
 
     # create
-    info = StreamInfo('Markers', 'Markers', 1, 0, 'int32', 'myuidw43536')
+    info = StreamInfo("Markers", "Markers", 1, 0, "int32", "myuidw43536")
 
     # next make an outlet
     outlet = StreamOutlet(info)
@@ -19,22 +19,21 @@ def present(duration=120):
     start = time()
 
     n_trials = 2000
-    iti = .2
-    jitter = .1
+    iti = 0.2
+    jitter = 0.1
     soa = 0.2
     record_duration = np.float32(duration)
 
     # Setup log
     position = np.random.randint(0, 2, n_trials)
-    trials = DataFrame(dict(position=position,
-                            timestamp=np.zeros(n_trials)))
+    trials = DataFrame(dict(position=position, timestamp=np.zeros(n_trials)))
 
     # graphics
-    mywin = visual.Window([1920, 1080], monitor="testMonitor", units="deg",
-                          fullscr=True)
-    grating = visual.GratingStim(win=mywin, mask='circle', size=20, sf=4)
-    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0,
-                                  rgb=[1, 0, 0])
+    mywin = visual.Window(
+        [1920, 1080], monitor="testMonitor", units="deg", fullscr=True
+    )
+    grating = visual.GratingStim(win=mywin, mask="circle", size=20, sf=4)
+    fixation = visual.GratingStim(win=mywin, size=0.2, pos=[0, 0], sf=0, rgb=[1, 0, 0])
 
     for ii, trial in trials.iterrows():
         # inter trial interval
@@ -42,8 +41,8 @@ def present(duration=120):
 
         # onset
         grating.phase += np.random.rand()
-        pos = trials['position'].iloc[ii]
-        grating.pos = [25*(pos-0.5), 0]
+        pos = trials["position"].iloc[ii]
+        grating.pos = [25 * (pos - 0.5), 0]
         grating.draw()
         fixation.draw()
         outlet.push_sample([markernames[pos]], time())
@@ -63,13 +62,18 @@ def present(duration=120):
 def main():
     parser = OptionParser()
 
-    parser.add_option("-d", "--duration",
-                      dest="duration", type='int', default=120,
-                      help="duration of the recording in seconds.")
+    parser.add_option(
+        "-d",
+        "--duration",
+        dest="duration",
+        type="int",
+        default=120,
+        help="duration of the recording in seconds.",
+    )
 
     (options, args) = parser.parse_args()
     present(options.duration)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eegnb/stimuli/__init__.py
+++ b/eegnb/stimuli/__init__.py
@@ -1,4 +1,4 @@
 from os import path
 
-FACE_HOUSE = path.join(path.dirname(__file__), 'visual', 'face_house')
-CAT_DOG = path.join(path.dirname(__file__), 'visual', 'cats_dogs')
+FACE_HOUSE = path.join(path.dirname(__file__), "visual", "face_house")
+CAT_DOG = path.join(path.dirname(__file__), "visual", "cats_dogs")


### PR DESCRIPTION
Used the wonderful [black](https://github.com/psf/black) to format the codebase.

Kind of a "meaningless" change (there are benefits to consistent formatting, but I won't argue them here), just wanted to put the suggestion out there.

Can wait for consideration until *after* all the upcoming hackathon PRs are merged (reapplying is trivial).

Someone will inevitably mention that this breaks `git blame` et al, but you can use `git blame --ignore-rev=<commit>` (or `--ignore-rev-file=<filename-with-commit-ids.txt>`) to have it ignore the style applying commits.

**Edit:** I've reconsidered running with `--skip-string-normalization` since the black docs explicltly recommended against it. Better doing things properly and once. 

For reference, here are counts of `'` vs `"`:

```
$ git grep -hoI "'" eegnb/ | wc --words
1562
$ git grep -hoI '"' eegnb/ | wc --words
646
```