### PR TITLE
fix: fixed pywinhook to only be a requirement on Windows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        pip install -r requirements-docs.txt
         pip install .
     - name: Build docs
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ brainflow==3.4.3
 gdown==3.12.2
 matplotlib==3.3.1
 pysocks==1.7.1
-pywinhook==1.6.0
+pywinhook==1.6.0; platform_system == "Windows"
 
 # Docs requirements
 sphinx==3.1.1


### PR DESCRIPTION
Fixes the broken CI (and general install) on macOS and Linux.

Also fixes the issue with building docs in CI (which used the removed `requirements-docs.txt`).