### PR TITLE
Debug/Fix CLI and OpenBCI Boards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
 
+eeg_notebooks.egg-info/
+
 # Built as part of docs
 doc/auto_examples
 doc/_build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__
 
-eeg_notebooks.egg-info/
+*.egg-info/
 
 # Built as part of docs
 doc/auto_examples

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -51,15 +51,16 @@ def intro_prompt():
         print("Please select your connection method:\n"
               "[0] usb dongle \n"
               "[1] wifi shield \n")
-        connect_idx = input("Enter connection method: ")
+        connect_idx = int(input("Enter connection method: "))
 
         # add "_wifi" suffix to the end of the board name for brainflow
         if connect_idx == 1:
             board_selection = board_selection + "_wifi"
+            ip_address = input("\nEnter Ganglion+WiFi IP Address: ")
         else:
             # if the ganglion is being used, you can enter optional Ganglion mac address
             if board_selection == 'ganglion':
-                mac_address = input("\nGanglion MAC Address (Press Enter to Autoscan): ")
+                ganglion_mac_address = input("\nGanglion MAC Address (Press Enter to Autoscan): ")
 
     # Experiment selection
     print("\nPlease select which experiment you would like to run: \n"
@@ -84,11 +85,13 @@ def intro_prompt():
     session_nb = int(input("Enter session #: "))
 
     # start the EEG device
-    if board_selection == 'ganglion':
-        # if the ganglion is chosen a MAC address should also be proviced
-        eeg_device = EEG(device=board_selection, mac_addr=mac_address)
+    if board_selection.startswith('ganglion'):
+        if board_selection == 'ganglion_wifi':
+            eeg_device = EEG(device=board_selection, ip_addr=ip_address)
+        else: 
+            eeg_device = EEG(device=board_selection, mac_addr=ganglion_mac_address)
     else:
-        eeg_device = EEG(device=board_selection)
+        eeg_device = EEG(device=board_selection, ip_addr=ip_address)
 
     # ask if they are ready to begin
     print("\nEEG device successfully connected!")

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -40,48 +40,48 @@ def intro_prompt():
           f"[10] {boards[10]} \n",
           f"[11] {boards[11]} \n")
 
-    board_idx = int(input('Enter Board Selection:'))
+    board_idx = int(input('Enter Board Selection: '))
     board_selection = board_codes[board_idx]    # Board_codes are the actual names to be passed to the EEG class
     print(f"Selected board {boards[board_idx]} \n")
 
     # Handles wifi shield connectivity selection if an OpenBCI board is being used
     if board_selection in ['cyton', 'cyton_daisy', 'ganglion']:
-        # if the ganglion is being used, will also need the MAC address
-        if board_selection == 'ganglion':
-            print("Please enter the Ganglions MAC address:\n")
-            mac_address = input("MAC address:")
 
         # determine whether board is connected via Wifi or BLE
         print("Please select your connection method:\n"
               "[0] usb dongle \n"
               "[1] wifi shield \n")
-        connect_idx = input("Enter connection method:")
+        connect_idx = input("Enter connection method: ")
 
         # add "_wifi" suffix to the end of the board name for brainflow
         if connect_idx == 1:
             board_selection = board_selection + "_wifi"
+        else:
+            # if the ganglion is being used, you can enter optional Ganglion mac address
+            if board_selection == 'ganglion':
+                mac_address = input("\nGanglion MAC Address (Press Enter to Autoscan): ")
 
     # Experiment selection
-    print("Please select which experiment you would like to run: \n"
+    print("\nPlease select which experiment you would like to run: \n"
           "[0] visual n170 \n"
           "[1] visual p300 \n"
           "[2] ssvep \n")
 
-    exp_idx = int(input('Enter Experiment Selection:'))
+    exp_idx = int(input('Enter Experiment Selection: '))
     exp_selection = experiments[exp_idx]
     print(f"Selected experiment {exp_selection} \n")
 
     # record duration
     print("Now, enter the duration of the recording (in seconds). \n")
-    duration = int(input("Enter duration:"))
+    duration = int(input("Enter duration: "))
 
     # Subject ID specification
-    print("Next, enter the ID# of the subject you are recording data from. \n")
-    subj_id = int(input("Enter subject ID#:"))
+    print("\nNext, enter the ID# of the subject you are recording data from. \n")
+    subj_id = int(input("Enter subject ID#: "))
 
     # Session ID specification
-    print("Next, enter the session number you are recording for. \n")
-    session_nb = int(input("Enter session #:"))
+    print("\nNext, enter the session number you are recording for. \n")
+    session_nb = int(input("Enter session #: "))
 
     # start the EEG device
     if board_selection == 'ganglion':
@@ -91,6 +91,7 @@ def intro_prompt():
         eeg_device = EEG(device=board_selection)
 
     # ask if they are ready to begin
+    print("\nEEG device successfully connected!")
     input("Press [ENTER] when ready to begin...")
 
     # generate the save file name

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -91,7 +91,7 @@ def intro_prompt():
         else: 
             eeg_device = EEG(device=board_selection, mac_addr=ganglion_mac_address)
     else:
-        eeg_device = EEG(device=board_selection, ip_addr=ip_address)
+        eeg_device = EEG(device=board_selection)
 
     # ask if they are ready to begin
     print("\nEEG device successfully connected!")

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -56,11 +56,16 @@ def intro_prompt():
         # add "_wifi" suffix to the end of the board name for brainflow
         if connect_idx == 1:
             board_selection = board_selection + "_wifi"
+
+        if board_selection == 'ganglion':
+            # If the Ganglion is being used, you can enter optional Ganglion mac address
+            ganglion_mac_address = input("\nGanglion MAC Address (Press Enter to Autoscan): ")    
+        elif board_selection == 'ganglion_wifi':
+            # IP address is required for this board configuration
             ip_address = input("\nEnter Ganglion+WiFi IP Address: ")
-        else:
-            # if the ganglion is being used, you can enter optional Ganglion mac address
-            if board_selection == 'ganglion':
-                ganglion_mac_address = input("\nGanglion MAC Address (Press Enter to Autoscan): ")
+        elif board_selection == 'cyton_wifi' or board_selection == 'cyton_daisy_wifi':
+            print(f"\n{boards[board_idx]} + WiFi is not supported. Please use the dongle that was shipped with the device.\n")
+            exit()
 
     # Experiment selection
     print("\nPlease select which experiment you would like to run: \n"

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -44,7 +44,7 @@ def intro_prompt():
     board_selection = board_codes[board_idx]    # Board_codes are the actual names to be passed to the EEG class
     print(f"Selected board {boards[board_idx]} \n")
 
-    # Handles wifi shield connectivity selection if an OpenBCI board is being used
+    # Handles connectivity selection if an OpenBCI board is being used
     if board_selection in ['cyton', 'cyton_daisy', 'ganglion']:
 
         # determine whether board is connected via Wifi or BLE

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -130,6 +130,7 @@ class EEG:
             self.brainflow_id = BoardIds.GANGLION_WIFI_BOARD.value
             if self.ip_addr is not None:
                 self.brainflow_params.ip_address = self.ip_addr
+                self.brainflow_params.ip_port = 6677
 
         elif self.device_name == 'cyton':
             self.brainflow_id = BoardIds.CYTON_BOARD.value
@@ -140,6 +141,7 @@ class EEG:
             self.brainflow_id = BoardIds.CYTON_WIFI_BOARD.value
             if self.ip_addr is not None:
                 self.brainflow_params.ip_address = self.ip_addr
+                self.brainflow_params.ip_port = 6677
 
         elif self.device_name == 'cyton_daisy':
             self.brainflow_id = BoardIds.CYTON_DAISY_BOARD.value
@@ -202,7 +204,7 @@ class EEG:
         data = data.T  # transpose data
 
         # get the channel names for EEG data
-        if self.brainflow_id == BoardIds.GANGLION_BOARD.value:
+        if self.brainflow_id == BoardIds.GANGLION_BOARD.value or self.brainflow_id == BoardIds.GANGLION_WIFI_BOARD.value:
             # if a ganglion is used, use recommended default EEG channel names
             ch_names = ['fp1', 'fp2', 'tp7', 'tp8']
         else:

--- a/eegnb/devices/utils.py
+++ b/eegnb/devices/utils.py
@@ -1,6 +1,9 @@
 import numpy as np
 import socket
 import platform
+import sys
+import glob
+import serial
 
 from brainflow import BoardShim, BoardIds
 
@@ -52,14 +55,6 @@ SAMPLE_FREQS = {
     'notion2': BoardShim.get_sampling_rate(BoardIds.NOTION_2_BOARD.value),
 }
 
-def get_openbci_usb():
-    if platform.system() == 'Linux':
-        return '/dev/ttyUSB0'
-    elif platform.system() == 'Windows':
-        return input('Please enter USB port for Windows: ')
-    elif platform.system() == 'Darwin':
-        return input("Please enter USB port for Mac OS: ")
-
 def create_stim_array(timestamps, markers):
     """ Creates a stim array which is the lenmgth of the EEG data where the stimuli are lined up
     with their corresponding EEG sample.
@@ -75,3 +70,46 @@ def create_stim_array(timestamps, markers):
         stim_array[stim_idx] = marker[0]
 
     return stim_array
+
+def get_openbci_usb():
+    print('\nGetting a list of available serial ports...')
+    port_list = serial_ports()
+    i = 0
+    for port in port_list:
+        print(f'[{i}] {port}')
+        i += 1
+    port_number = input('Select Port(number): ')
+    if port_number == '':
+        return port_list[int(input('This field is required. Select Port(number): '))]
+    else:
+        return str(port_list[int(port_number)]).split(' - ')[0]
+
+def serial_ports():
+    """ Lists serial port names
+
+        :raises EnvironmentError:
+            On unsupported or unknown platforms
+        :returns:
+            A list of the serial ports available on the system
+    """
+    if sys.platform.startswith('win'):
+        ports = ['COM%s' % (i + 1) for i in range(256)]
+    elif sys.platform.startswith('linux') or sys.platform.startswith('cygwin'):
+        # this excludes your current terminal "/dev/tty"
+        ports = glob.glob('/dev/tty[A-Za-z]*')
+    elif sys.platform.startswith('darwin'):
+        # Look for .cu instead of only for Mac so that it works with BrainFlow.
+        ports = glob.glob('/dev/cu.*')
+    else:
+        raise EnvironmentError('Unsupported platform')
+
+    #result = []
+    #for port in ports:
+        #try:
+            #s = serial.Serial(port)
+            #s.close()
+            #result.append(port)
+        #except (OSError, serial.SerialException):
+            #pass
+    #return result
+    return serial.tools.list_ports.comports()

--- a/eegnb/devices/utils.py
+++ b/eegnb/devices/utils.py
@@ -1,8 +1,6 @@
 import numpy as np
 import socket
 import platform
-import sys
-import glob
 import serial
 
 from brainflow import BoardShim, BoardIds

--- a/eegnb/devices/utils.py
+++ b/eegnb/devices/utils.py
@@ -85,31 +85,4 @@ def get_openbci_usb():
         return str(port_list[int(port_number)]).split(' - ')[0]
 
 def serial_ports():
-    """ Lists serial port names
-
-        :raises EnvironmentError:
-            On unsupported or unknown platforms
-        :returns:
-            A list of the serial ports available on the system
-    """
-    if sys.platform.startswith('win'):
-        ports = ['COM%s' % (i + 1) for i in range(256)]
-    elif sys.platform.startswith('linux') or sys.platform.startswith('cygwin'):
-        # this excludes your current terminal "/dev/tty"
-        ports = glob.glob('/dev/tty[A-Za-z]*')
-    elif sys.platform.startswith('darwin'):
-        # Look for .cu instead of only for Mac so that it works with BrainFlow.
-        ports = glob.glob('/dev/cu.*')
-    else:
-        raise EnvironmentError('Unsupported platform')
-
-    #result = []
-    #for port in ports:
-        #try:
-            #s = serial.Serial(port)
-            #s.close()
-            #result.append(port)
-        #except (OSError, serial.SerialException):
-            #pass
-    #return result
     return serial.tools.list_ports.comports()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ gdown==3.12.2
 matplotlib==3.3.1
 pysocks==1.7.1
 pywinhook==1.6.0; platform_system == "Windows"
+pyserial==3.5
 
 # Docs requirements
 sphinx==3.1.1


### PR DESCRIPTION
- [x] Fixes #40
- [x] Add support for Ganglion+WiFi via CLI
- [x] Add newline characters as needed to make input prompts more readable and organized for users

@JohnGriffiths @JadinTredup @m9h


**Full Console Log using Input Prompt and Ganglion w/ BLED112 Dongle on Mac OS 10.15.7:**
```
(eeg-nb-main) Richard-Waltmans-iMac-4:eeg-notebooks Richard$ eegnb runexp -ip
run command line prompt script
Welcome to NeurotechX EEG Notebooks. 
Please enter the integer value corresponding to your EEG device: 
[0] None 
[1] Muse2016 
[2] Muse2 
[3] MuseS 
[4] OpenBCI Ganglion 
[5] OpenBCI Cyton 
[6] OpenBCI Cyton + Daisy 
[7] G.Tec Unicorn 
[8] BrainBit 
[9] Notion 1 
[10] Notion 2 
 [11] Synthetic 

Enter Board Selection: 4
Selected board OpenBCI Ganglion 

Please select your connection method:
[0] usb dongle 
[1] wifi shield 

Enter connection method: 0

Ganglion MAC Address (Press Enter to Autoscan): 

Please select which experiment you would like to run: 
[0] visual n170 
[1] visual p300 
[2] ssvep 

Enter Experiment Selection: 0
Selected experiment visual-N170 

Now, enter the duration of the recording (in seconds). 

Enter duration: 12

Next, enter the ID# of the subject you are recording data from. 

Enter subject ID#: 1

Next, enter the session number you are recording for. 

Enter session #: 1

Getting a list of available serial ports...
[0] /dev/cu.MyLovesAirPods-Wireless - n/a
[1] /dev/cu.UEBOOM2-LWACP - n/a
[2] /dev/cu.Bluetooth-Incoming-Port - n/a
[3] /dev/cu.usbserial-DM00D7TW - FT231X USB UART - FT231X USB UART
[4] /dev/cu.usbmodem11 - Low Energy Dongle - CDC data
Select Port(number): 4
[2020-12-02 23:20:09.628] [brainflow_logger] [info] incomming json: {
    "ip_address": "",
    "ip_port": 0,
    "ip_protocol": 0,
    "mac_address": "",
    "other_info": "",
    "serial_number": "",
    "serial_port": "/dev/cu.usbmodem11",
    "timeout": 0
}
[2020-12-02 23:20:09.629] [brainflow_logger] [info] use 15 as a timeout for device discovery and for callbacks
[2020-12-02 23:20:09.629] [brainflow_logger] [info] mac address is not specified, try to find ganglion without it

EEG device successfully connected!
Press [ENTER] when ready to begin...
21.4626         WARNING         User requested fullscreen with size [1600  900], but screen is actually [2560, 1440]. Using actual size
23.0569         WARNING         User requested fullscreen with size [1600  900], but screen is actually [2560, 1440]. Using actual size
[2020-12-02 23:20:20.491] [brainflow_logger] [info] use command b to start streaming
```