### PR TITLE
updating doc to reflect Muse working on Linux without a dongle

### DIFF
--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -2,12 +2,12 @@
 Installation
 ************
 
-EEG-Notebooks is a Python library. It runs on all major operating systems (Windows, Linux, Mac). 
+EEG-Notebooks is a Python library. It runs on all major operating systems (Windows, Linux, Mac).
 
-If you do not have Python installed, or are not particularly familiar with using it, then we highly recommend downloading and installing the Miniconda(3) Python(3) distribution. For users who prefer to use `VirtualEnv`  (`venv`) than `conda` for Python environment management, we provide equivalent installation and usage instructions where relevant. 
+If you do not have Python installed, or are not particularly familiar with using it, then we highly recommend downloading and installing the Miniconda(3) Python(3) distribution. For users who prefer to use `VirtualEnv`  (`venv`) than `conda` for Python environment management, we provide equivalent installation and usage instructions where relevant.
 
 
-The principal purpose of EEG-Notebooks is to allow users to run and create cognitive neuroscience experiments using consumer-grade EEG systems. A secondary, complementary, purpose of the tool is to provide various functionalities for the organization, analysis and visualization of the data collected in these experiments. 
+The principal purpose of EEG-Notebooks is to allow users to run and create cognitive neuroscience experiments using consumer-grade EEG systems. A secondary, complementary, purpose of the tool is to provide various functionalities for the organization, analysis and visualization of the data collected in these experiments.
 
 As such, there are two principal modes of usage:
 
@@ -18,13 +18,13 @@ As such, there are two principal modes of usage:
 
 As may be expected, the installation and setup steps for mode 2 are simpler than mode 1, with the difference being additional hardware and software requirements for measuring, streaming and recording EEG data. These requirements, which are device- and operating system-specific, are as follows:
 
-- `Muse 2016`, `Muse 2`, and `Muse S` recordings on **Windows** require the third-party streaming tool `BlueMuse`. `Bluemuse` deals with establishing a connection between the eeg device and the stimulus-delivery laptop/desktop. 
+- `Muse 2016`, `Muse 2`, and `Muse S` recordings on **Windows** require the third-party streaming tool `BlueMuse`. `Bluemuse` deals with establishing a connection between the eeg device and the stimulus-delivery laptop/desktop.
 
-- `Muse 2016`, `Muse 2`, and `Muse S` recordings on **Linux** and **Mac** require a BLED112 dongle (see below). The BLED112 dongle bypasses the native bluetooth hardware, which is not compatible with `muse` device streaming. 
+- `Muse 2016`, `Muse 2`, and `Muse S` recordings on **Mac** require a BLED112 dongle (see below). The BLED112 dongle bypasses the native bluetooth hardware, which is not compatible with `muse` device streaming.
 
-- `OpenBCI` recordings work the same for all operating systems, and do not require any additional hardware or software. 
+- `OpenBCI` recordings work the same for all operating systems, and do not require any additional hardware or software.
 
-- 'Usage mode 2' above (no EEG recordings) can be done easily on any operating system without any extra hardware or software, as well as on free temporary cloud compute servers through `Binder` and `GoogleColab`, which we provide instructions for. 
+- 'Usage mode 2' above (no EEG recordings) can be done easily on any operating system without any extra hardware or software, as well as on free temporary cloud compute servers through `Binder` and `GoogleColab`, which we provide instructions for.
 
 
 
@@ -49,7 +49,7 @@ Use the following commands to download the repo, create and activate a conda or 
            conda activate "eeg-notebooks"
 
            conda install git
-           
+
            conda install pip
 
            git clone https://github.com/NeuroTechX/eeg-notebooks
@@ -57,8 +57,8 @@ Use the following commands to download the repo, create and activate a conda or 
            cd eeg-notebooks
 
            pip install -e .
-           
-           
+
+
     .. tab:: Virtualenv
 
        .. tabs::
@@ -78,7 +78,7 @@ Use the following commands to download the repo, create and activate a conda or 
                  cd eeg-notebooks
 
                  pip install -e .
-                 
+
           .. tab:: Linux or MacOS
 
              .. code-block:: bash
@@ -94,7 +94,7 @@ Use the following commands to download the repo, create and activate a conda or 
                  cd eeg-notebooks
 
                  pip install -e .
-                 
+
 
 
 **Add the new environment to the jupyter kernel list**
@@ -145,7 +145,7 @@ Start a jupyter notebooks session and you will be presented with the eeg-noteboo
 MUSE Requirements
 ======================
 
-The InteraXon MUSE streams EEG over bluetooth. There are additional hardware and software requirements for making recordings with MUSE devices, which are different across operating systems. 
+The InteraXon MUSE streams EEG over bluetooth. There are additional hardware and software requirements for making recordings with MUSE devices, which are different across operating systems.
 
 
 MUSE recordings on windows: BlueMuse
@@ -154,12 +154,16 @@ MUSE recordings on windows: BlueMuse
 BlueMuse is a Windows 10 program that allows communication between a Muse headband and a computer’s native bluetooth drivers using the LSL communication protocol. To install, go the the `BlueMuse github repo <https://github.com/kowalej/BlueMuse>`_ and follow the installation instructions.
 
 
-
-MUSE recordings on Mac+Linux: BLED112 Dongle
+MUSE recordings on Mac: BLED112 Dongle
 ---------------------------------------------
 
-Unfortunately, the native bluetooth driver on Mac and Linux cannot be used with eeg-notebooks. To run on these operating systems, it is necessary to purchase a `BLED112 USB Dongle <https://www.silabs.com/wireless/bluetooth/bluegiga-low-energy-legacy-modules/device.bled112/>`_. Note: this is a 'special' bluetooth dongle; standard bluetooth dongles will not work. 
+Unfortunately, the native bluetooth driver on Mac cannot be used with eeg-notebooks. To run on this operating system, it is necessary to purchase a `BLED112 USB Dongle <https://www.silabs.com/wireless/bluetooth/bluegiga-low-energy-legacy-modules/device.bled112/>`_. Note: this is a 'special' bluetooth dongle; standard bluetooth dongles will not work.
 
+
+MUSE recordings on Linux
+---------------------------------------------
+
+Streaming MUSE data on Linux works without a dongle (which relies on `pygatt`'s `GATT` backend), but might be more stable with the `BLED112 USB Dongle` and `BGAPI` backend.
 
 
 Issues

--- a/doc/getting_started/streaming.md
+++ b/doc/getting_started/streaming.md
@@ -1,15 +1,10 @@
 # Initiating an EEG Stream
 
-Before getting going with running an experiment, it is important to first verify that a connection between your computer and EEG device has been successfully established, and the raw EEG data is being streamed and recorded properly. 
+Before getting going with running an experiment, it is important to first verify that a connection between your computer and EEG device has been successfully established, and the raw EEG data is being streamed and recorded properly.
 
-The exact steps for this vary with the device (MUSE, OpenBCI, others) and operating system (Windows, Mac, Linux) used. When using these instructions, you should make sure you are consulting the section appropriate for your combination of device and OS. 
+The exact steps for this vary with the device (MUSE, OpenBCI, others) and operating system (Windows, Mac, Linux) used. When using these instructions, you should make sure you are consulting the section appropriate for your combination of device and OS.
 
-
-
-
-
-
-Initiating an EEG stream is a relatively easy process using the `eegnb.devices.eeg.EEG` class which abstracts the 
+Initiating an EEG stream is a relatively easy process using the `eegnb.devices.eeg.EEG` class which abstracts the
 the various devices and backends behind one easy call.
 
 ```python
@@ -30,27 +25,27 @@ These two lines of code abstract a lot of the heavy lifting with respect to swit
 Below is a lst of supported devices and the information needed to connect to each when running the library. Each section also provides common troubleshooting tips for each. If you encounter any errors when connecting which are not listed below please report these on the issues page.
 
 ### Interaxon Muse
-**Device Names:** *'muse2016'*, *'muse2'*, and *'museS'*  
-**Backend:** MuseLSL  
+**Device Names:** *'muse2016'*, *'muse2'*, and *'museS'*
+**Backend:** MuseLSL
 **Needed Parameters:**  No other parameters are needed, however, if running on Windows 10, then you must also start blue muse before running the experiments.
 
 #### Using the Muse on Windows
-To initialize the EEG stream on window you must have Bluemuse running in the background. Open a terminal and start 
-bluemuse using `start bluemuse;` which should open up a GUI. If you have the USB dongle plugged in and the muse turned on 
+To initialize the EEG stream on window you must have Bluemuse running in the background. Open a terminal and start
+bluemuse using `start bluemuse;` which should open up a GUI. If you have the USB dongle plugged in and the muse turned on
 then you should see a GUI which looks something like the image below.
 
 ![fig](../img/bluemuse.PNG)
 
-Once you press the **Start Streaming** button, muse will be streaming data in the background and can the above code can 
+Once you press the **Start Streaming** button, muse will be streaming data in the background and can the above code can
 be run to begin the notebooks interfacing with the bluemuse backend.
 
 ### OpenBCI Ganglion
 ![fig](../img/ganglion.png)
 
-**Device Name:** *'ganglion'*  
-**Backend:** Brainflow  
-**Needed Parameters:**  
-* *mac_addr*: MAC Address (see below for instructions on getting the MAC address)   
+**Device Name:** *'ganglion'*
+**Backend:** Brainflow
+**Needed Parameters:**
+* *mac_addr*: MAC Address (see below for instructions on getting the MAC address)
 
 **Optional Parameters:**
 * *serial_port*: Serial port containing the USB dongle. If it does not automatically discover the USB port see the instructions below for finding the serial port in the OpenBCI GUI.
@@ -63,53 +58,53 @@ be run to begin the notebooks interfacing with the bluemuse backend.
 ### OpenBCI Cyton
 ![fig](../img/cyton.png)
 
-**Device Name:** *'cyton'*  
-**Backend:** Brainflow  
-**Needed Parameters:**  
+**Device Name:** *'cyton'*
+**Backend:** Brainflow
+**Needed Parameters:**
 **Optional Parameters:**
 
 ### OpenBCI Cyton + Daisy
 ![fig](../img/cyton_daisy.png)
-**Device Name:** *'cyton_daisy'*    
-**Backend:** Brainflow  
-**Needed Parameters:**  
+**Device Name:** *'cyton_daisy'*
+**Backend:** Brainflow
+**Needed Parameters:**
 **Optional Parameters:**
 
 ### Neurosity Notion (versions 1 and 2)
 ![fig](../img/notion.png)
-**Device Name:** *'notion1'* or *'notion2'*  
-**Backend:** Brainflow  
+**Device Name:** *'notion1'* or *'notion2'*
+**Backend:** Brainflow
 **Needed Parameters:**  No additional parameters are needed to connect to the Notion. It is necessary however to make sure the Notion is on the same network and readable by Neurosity's developer console.
 
 #### Connecting on Windows
 In order to connect to the Notion on Windows you must first turn off your network firewall for the Open Sound Control (OSC) protocol to function for the notion.
 
 ### BrainBit EEG Headband
-![fig](../img/brainbit.png)  
-**Device Name:** *'brainbit'*  
+![fig](../img/brainbit.png)
+**Device Name:** *'brainbit'*
 **Backend:** Brainflow
 
 ### G.Tec Unicorn
 ![fig](../img/gtec-unicorn.jpg)
-**Device Name:** *'unicorn'*  
+**Device Name:** *'unicorn'*
 **Backend:** Brainflow
 
 
 
 ## Initiating a Muse stream in Windows using Bluemuse
-To initialize the EEG stream on window you must have Bluemuse running in the background. Open a terminal and start 
-bluemuse using `start bluemuse;` which should open up a GUI. If you have the USB dongle plugged in and the muse turned on 
+To initialize the EEG stream on window you must have Bluemuse running in the background. Open a terminal and start
+bluemuse using `start bluemuse;` which should open up a GUI. If you have the USB dongle plugged in and the muse turned on
 then you should see a GUI which looks something like the image below.
 
 ![fig](../img/bluemuse.PNG)
 
-Once you press the **Start Streaming** button, muse will be streaming data in the background and can the above code can 
+Once you press the **Start Streaming** button, muse will be streaming data in the background and can the above code can
 be run to begin the notebooks interfacing with the bluemuse backend.
 
 
 ## Finding the USB port of the OpenBCI USB dongle
-If the library is not connecting to an OpenBCI device this might be an issue of defaulting to the wrong serial 
-port. If this is happening you can check the serial port of the dongle by opening the OpenBCI GUI and navigating to the 
+If the library is not connecting to an OpenBCI device this might be an issue of defaulting to the wrong serial
+port. If this is happening you can check the serial port of the dongle by opening the OpenBCI GUI and navigating to the
 menu pictures below.
 
 ![fig](../img/windows_usb_select.PNG)
@@ -128,6 +123,6 @@ eeg = EEG(
 eeg.start()
 ```
 
-This issue is more common on windows installations, and the image above is shown on a windows OS. However it might still 
+This issue is more common on windows installations, and the image above is shown on a windows OS. However it might still
 be possible for it to happen in Linux and in any case, the process for determining the USB port of the dongle is the same.
 


### PR DESCRIPTION
`muse-lsl` does seem to work on Linux without a dongle using this workaround: https://github.com/alexandrebarachant/muse-lsl/pull/141 This PR modifies the documentation to reflect this.

We should probably wait for https://github.com/alexandrebarachant/muse-lsl/pull/141 to be merged, or another solution to be found, before merging this PR.