### PR TITLE
Fix build and test for ubuntu builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,16 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
         python-version: 3.6
-    - name: Install APT dependencies
-      run: |
-        sudo apt-get install -y git build-essential apt-utils wget libfreetype6 libpng-dev libopenblas-dev gcc gfortran libsnappy-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,24 @@ jobs:
         (New-Object System.Net.WebClient).DownloadFile("http://prdownloads.sourceforge.net/swig/swigwin-4.0.1.zip","swigwin-4.0.1.zip");
         Expand-Archive .\swigwin-4.0.1.zip .;
         echo "$((Get-Item .).FullName)/swigwin-4.0.1" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Install APT dependencies
-      if: "startsWith(runner.os, 'ubuntu')"
+    - name: Setup Display
+      if: "startsWith(runner.os, 'Linux')"
       run: |
-        sudo apt-get install -y git build-essential apt-utils wget libfreetype6 libpng-dev libopenblas-dev gcc gfortran libsnappy-dev
+        sudo apt -y install xvfb libgtk-3-dev freeglut3-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
         pip install . -r requirements.txt
+        pip install -e .
+    - name: Run eegnb
+      if: "startsWith(runner.os, 'Linux')"
+      run: |
+        Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> xvfb.log &
+        export DISPLAY=:0
+        echo "first test: print help menu"
+        eegnb --help
+        echo "second test: runexp with no args"
+        eegnb runexp
     #- name: Typecheck
     #  run: |
     #    mypy --ignore-missing-imports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Setup Display
       if: "startsWith(runner.os, 'Linux')"
       run: |
+        # xvfb is a dependency to create a virtual display
+        # libgtk-3-dev is a requirement for wxPython
+        # freeglut3-dev is a requirement for a wxPython dependency
         sudo apt -y install xvfb libgtk-3-dev freeglut3-dev
     - name: Install dependencies
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ matplotlib==3.3.1
 pysocks==1.7.1
 pywinhook==1.6.0; platform_system == "Windows"
 pyserial==3.5
+h5py>=3.1.0; platform_system == "Linux"
+pyo>=1.0.3; platform_system == "Linux"
+wxPython>=4.1.1; platform_system == "Linux"
 
 # Docs requirements
 sphinx==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pywinhook==1.6.0; platform_system == "Windows"
 pyserial==3.5
 h5py>=3.1.0; platform_system == "Linux"
 pyo>=1.0.3; platform_system == "Linux"
-wxPython>=4.1.1; platform_system == "Linux"
+wxPython>=4.0 ; platform_system == "Linux"
 
 # Docs requirements
 sphinx==3.1.1
@@ -30,4 +30,3 @@ numpydoc==1.1.0
 recommonmark==0.6.0
 versioneer==0.19
 rst2pdf==0.98
-


### PR DESCRIPTION
**Fix build and test for ubuntu builds**

This fixes the ubuntu builds and tests an initial sanity test of 'is
eegnb installed correctly?'

Changes:
- use linux for 'runner.os' query string
- create virtual display for Pyglet dependencies in PsychoPy
- add freeglut3-dev package for PyschoPY transitive deps
- install wxPython, `pyo`, and `h5py` python packages
- add two 'sanity' test running `eegnb`
- add packages required for linux build in requirements.txt
- build docs on macOS to avoid having to install wxPython

Note:
wxPython is required for Linux bulids and takes ~35 minutes to build on
the current CI Runner (as well as locally). We can optimize in the
future by building + storing the wxPython egg.


**More Background**
Right now our CI/CD Workflow `test` action is not actually testing anything other than a successful `pip install -r requirements`.

What we need to do is fully install `eegnb` and run some initial 'sanity' checks to make sure all dependencies are actually installed, and basic functionality works.

This was inspired from #26, after testing things locally and finding issues getting things to run properly (see: https://github.com/NeuroTechX/eeg-notebooks/pull/26#issuecomment-738545393)

**Work that still needs to be done**
- fix macOS builds/install in CI system
- fix Windows builds/install in CI system