### PR TITLE
added ci doc building using ssh agent action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,4 +31,6 @@ jobs:
 
     - name: Build docs
       run: |
+        git config --global user.email "eeg-notebooks-ci@github.com"
+        git config --global user.name "eeg-notebooks github repo CI"
         cd doc && make install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: set up ssh access  
-    - uses: webfactory/ssh-agent@v0.4.1
+    - name: Set up ssh access  
+      uses: webfactory/ssh-agent@v0.4.1
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Set up Python 3.6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,8 @@ jobs:
     - name: Set up ssh-agent
       uses: yakuhzi/action-ssh-agent@v1
       with:
-        public: ${{ secrets.SSH_PUBLIC_KEY }}
-        private: ${{ secrets.SSH_PRIVATE_KEY }}
+        ssh-public-key: ${{ secrets.SSH_PUBLIC_KEY }}
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Build docs
       run: |
         cd doc && make install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,12 @@ jobs:
         pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython
 
         pip install .
+
+    - name: Set up ssh-agent
+      uses: yakuhzi/action-ssh-agent@v1
+      with:
+        public: ${{ secrets.SSH_PUBLIC_KEY }}
+        private: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Build docs
       run: |
         cd doc && make install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+    - name: set up ssh access  
+    - uses: webfactory/ssh-agent@v0.4.1
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
@@ -26,8 +30,5 @@ jobs:
         pip install .
 
     - name: Build docs
-      uses: webfactory/ssh-agent@v0.4.1
-      with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       run: |
         cd doc && make install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,11 +25,9 @@ jobs:
 
         pip install .
 
-    - name: Set up ssh-agent
-      uses: yakuhzi/action-ssh-agent@v1
-      with:
-        ssh-public-key: ${{ secrets.SSH_PUBLIC_KEY }}
-        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Build docs
+      uses: webfactory/ssh-agent@v0.4.1
+      with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       run: |
         cd doc && make install


### PR DESCRIPTION

Spent a long time researching github actions for doc building. 

All we really want (I think) is to be able to run `make install`, and grant gh-pages push access so it can push the built docs to this repo's gh-pages branch. 

The most comprehensible solution I found for this was the [ssh agent action](https://github.com/yakuhzi/setup-ssh-agent) that (I believe) initializes SSH access using keys that I have added to the repo's 'secrets'. 

Let's see if it works. 

