### PR TITLE
add gh-pages publish action to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
         cd doc && make html
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/master'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: doc/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3
       with:
-	github_token: ${{ secrets.GITHUB_TOKEN }}
-	publish_dir: ./html
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: doc/_build/html
  

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,4 +26,10 @@ jobs:
         pip install .
     - name: Build docs
       run: |
-        cd doc && make install
+        cd doc && make html
+    - name: Deploy Docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+	github_token: ${{ secrets.GITHUB_TOKEN }}
+	publish_dir: ./html
+ 


### PR DESCRIPTION
Use peaceiris/actions-gh-pages action to publish gh-pages branch

This action comes from a [well-known actions contributor](https://github.blog/2020-03-22-github-action-hero-shohei-ueda/)

More info regarding considerations in choosing this particular
action over other methods:

Github has a great section titled the  [Using third-party actions](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions)
in their Security Hardening GH Actions documentation.

The gist of this section is basically:
- audit the third-party code
- lock down to a commit (if you're paranoid, or version tag if you're
not too worried)

They have a really important section titled [Considering cross-repository access](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#considering-cross-repository-access).
Summary of this particular section is is, github recommends the following access methods for
github actions (in order of high recommendation to 'please avoid at all
costs')
-[GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)
- repository deploy key
-github app tokens
- personal access tokens
- ssh keys on a user account