### PR TITLE
Aobinputfix

### DIFF
--- a/eegnb/experiments/auditory_oddball/aMMN.py
+++ b/eegnb/experiments/auditory_oddball/aMMN.py
@@ -12,7 +12,7 @@ from eegnb import generate_save_fn
 
 
 def present(
-    save_fn: str,
+    save_fn: None,
     duration=120,
     stim_types=None,
     itis=None,

--- a/eegnb/experiments/auditory_oddball/aob.py
+++ b/eegnb/experiments/auditory_oddball/aob.py
@@ -8,7 +8,7 @@ __title__ = "Auditory oddball (orig)"
 
 
 def present(
-    save_fn: str,
+    save_fn = None,
     eeg=None,
     duration=120,
     n_trials=2010,

--- a/eegnb/experiments/auditory_ssaep/ssaep.py
+++ b/eegnb/experiments/auditory_ssaep/ssaep.py
@@ -19,7 +19,7 @@ __title__ = "Auditory SSAEP (orig)"
 
 
 def present(
-    save_fn: str,
+    save_fn: None,
     duration=120,
     n_trials=2010,
     iti=0.5,


### PR DESCRIPTION
Just changed some experiment arguments to allow the `present` functions to work when an `eeg` object isn't supplied, without requiring an output filepath