### PR TITLE
ssaep volumefadingfixes

### DIFF
--- a/eegnb/experiments/auditory_ssaep/ssaep_onefreq.py
+++ b/eegnb/experiments/auditory_ssaep/ssaep_onefreq.py
@@ -64,8 +64,8 @@ def present(duration=365, eeg=None, save_fn=None, iti = 0., soa = 1.0, jitter = 
     mywin.flip()
 
 	
-	# Show the instructions screen
-    show_instructions(10)
+    # Show the instructions screen
+    show_instructions(duration)
     
 
     # start the EEG stream=

--- a/eegnb/experiments/auditory_ssaep/ssaep_onefreq.py
+++ b/eegnb/experiments/auditory_ssaep/ssaep_onefreq.py
@@ -15,7 +15,7 @@ import numpy as np
 from pandas import DataFrame
 from psychopy import prefs
 
-prefs.general["audioLib"] = ["pygame"]
+#prefs.general["audioLib"] = ["pygame"]
 from psychopy import visual, core, event, sound
 from pylsl import StreamInfo, StreamOutlet
 from scipy import stats
@@ -76,19 +76,19 @@ def present(duration=365, eeg=None, save_fn=None, iti = 0., soa = 1.0, jitter = 
         # Intertrial interval
         core.wait(iti + np.random.rand() * jitter)
 
-        # Select stimulus frequency
-        ind = trials["stim_freq"].iloc[ii]
-        auds[ind].stop()
-        auds[ind].play()
+        # Create auditory sound object and play tone
+        aud = sound.Sound(am1)
+        aud.setVolume(0.8)
+        aud.play()
 
         # Push sample
         if eeg:
             timestamp = time()
             if eeg.backend == "muselsl":
-                marker = [markernames[ind]]
+                marker = [markernames[1]]
                 marker = list(map(int, marker))
             else:
-                marker = markernames[ind]
+                marker = markernames[1]
             eeg.push_sample(marker=marker, timestamp=timestamp)
 
         # offset


### PR DESCRIPTION

Fixes an issue with volume fading out in `ssaep_onefreq` experiment by placing the sound object creation inside the trials loop. 

Also a few other improvements to the code. 