### PR TITLE
Configures issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: 🐛 Bug report
+about: Report errors or unexpected behavior
+title: ''
+labels: bug,needs-triage
+assignees: ''
+
+---
+
+## ℹ Computer information
+
+- Platform OS (e.g Windows, Mac, Linux etc): 
+- Python Version:
+- Brain Interface Used (e.g Muse, OpenBCI, Notion etc):
+
+## 📝 Provide detailed reproduction steps (if any)
+
+1. …
+2. …
+3. …
+
+### ✔️ Expected result
+
+_What is the expected result of the above steps?_
+
+### ❌ Actual result
+
+_What is the actual result of the above steps?_
+
+## 📷 Screenshots
+
+_Are there any useful screenshots? WinKey+Shift+S (Windows) / Shift+Command+4 (MacOS) and then just paste them directly into the form_

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,0 +1,14 @@
+---
+name: "\U0001F4DA Documentation Issue"
+about: Report issues in our documentation
+title: ''
+labels: docs,needs-triage
+assignees: ''
+
+---
+
+<!-- Briefly describe which document needs to be corrected and why. -->
+
+## 📝 Provide a description of requested docs changes
+
+_What is the purpose and what should be changed?_

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: "⭐ Feature request"
+about: Propose something new.
+title: ''
+labels: needs-triage
+assignees: ''
+
+---
+
+## 📝 Provide a description of the new feature
+
+_What is the expected behavior of the proposed feature?  What is the scenario this would be used?_
+
+---
+
+If you'd like to see this feature implemented, add a 👍 reaction to this post.


### PR DESCRIPTION
This PR configures issue templates to allow people get the most out of issues. Templates are for:
- bug reports
- documentation issues
- feature requests.

People will still be able to create blank issues outside of these predefined ones.