### PR TITLE
ci: added minimal testing setup with coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,14 @@ jobs:
         fi
         eegnb --help
         eegnb runexp --help
+    - name: Run examples with coverage
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> xvfb.log &
+          export DISPLAY=:0
+        fi
+        pytest
 
   typecheck:
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ doc/_build
 
 # Built by auto_examples
 examples/visual_cueing/*.csv
+
+# tests/coverage artifacts
+.coverage
+coverage.xml
+htmlcov

--- a/eegnb/experiments/visual_baselinetask/baseline_task.py
+++ b/eegnb/experiments/visual_baselinetask/baseline_task.py
@@ -18,7 +18,7 @@ outlet = StreamOutlet(info)
 start = time()
 
 # Initialize stimuli
-aud1 = sound.Sound("C", octave=5, sampleRate=44100, secs=0.5, bits=8)
+aud1 = sound.Sound("C", octave=5, sampleRate=44100, secs=0.5)
 aud1.setVolume(0.025)
 
 # Setup graphics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ addopts = """
 """
 testpaths = [
     "eegnb",
-    "examples",
+    "tests",
+    #"examples",
 ]
 python_files = ["*.py", "*.ipynb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = """
+    --cov=eegnb
+    --cov-report=term
+    --cov-report=xml
+    --cov-report=html
+    --nbval-lax
+    --current-env
+    --ignore-glob 'examples/**.py'
+    --ignore-glob '**/baseline_task.py'
+"""
+testpaths = [
+    "eegnb",
+    "examples",
+]
+python_files = ["*.py", "*.ipynb"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,9 @@ pysocks==1.7.1
 pyserial==3.5
 h5py>=3.1.0
 pyo>=1.0.3; platform_system == "Linux"
+
+# This might try to build from source on linux (since there are no wheels for Linux on PyPI)
+# You can pass `--find-links=https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/` your `pip install` to use the prebuilt wheels at the link.
 wxPython>=4.0 ; platform_system == "Linux"
 click
 
@@ -26,7 +29,10 @@ pywinhook>=1.6.0 ; platform_system == "Windows" and (python_version == "3.7" or 
 pywinhook @ https://github.com/ActivityWatch/wheels/raw/master/pywinhook/pyWinhook-1.6.2-cp39-cp39-win_amd64.whl ; platform_system == "Windows" and python_version == "3.9"
 
 # Test requirements
-mypy>=0.790
+mypy
+pytest
+pytest-cov
+nbval
 
 # Docs requirements
 sphinx==3.1.1

--- a/tests/test_empty.py
+++ b/tests/test_empty.py
@@ -1,0 +1,2 @@
+def test_empty():
+    assert True


### PR DESCRIPTION
fixes #77 

This simply runs all the examples with pytest + pytest-cov (for coverage) + nbval (for `.ipynb` files).

All the `*.py` files in the example folder are ignored since I'm not sure how to deal with the test collection when the entire file is the test (and may do things that require interaction). 

Since most of the notebooks seem to not run correctly I think it might make sense to try and figure out how to run the auto_examples as tests, but I can't figure out a way for pytest to treat each file like a test without running it at collection-time...