### PR TITLE
build(deps): removed jupyter as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ numpy==1.19.4
 mne>=0.20.8
 seaborn==0.9.0
 pyriemann==0.2.6
-jupyter==1.0.0
 muselsl>=2.0.2
 brainflow==3.7.2
 gdown==3.12.2


### PR DESCRIPTION
`jupyter` is a metapackage that I doubt is actually needed (and will override peoples' local jupyter installs, which is bad).

Might be that we should depend on one of its constituent parts, we'll see what CI says...