### PR TITLE
feat: added signal quality check to CLI

### DIFF
--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -322,3 +322,252 @@ def plot_highlight_regions(
     sns.despine()
 
     return fig, axes
+
+
+
+
+# Bjareholt Tools
+# ==================
+
+
+# From     https://github.com/ErikBjare/thesis/blob/master/src/eegwatch/devices/base.py 
+# -------
+
+
+import logging
+from typing import List, Dict
+from abc import ABCMeta, abstractmethod
+
+import numpy as np
+
+
+logger = logging.getLogger(__name__)
+
+
+def _check_samples(
+    buffer: np.ndarray, channels: List[str], max_uv_abs=200
+) -> Dict[str, bool]:
+    # TODO: Better signal quality check
+    chmax = dict(zip(channels, np.max(np.abs(buffer), axis=0)))
+    return {ch: maxval < max_uv_abs for ch, maxval in chmax.items()}
+
+
+def test_check_samples():
+    buffer = np.array([[9.0, 11.0, -5, -13]])
+    assert {"TP9": True, "AF7": False, "AF8": True, "TP10": False} == _check_samples(
+        buffer, channels=["TP9", "AF7", "AF8", "TP10"], max_uv_abs=10
+    )
+
+
+# From    https://github.com/ErikBjare/thesis/blob/master/src/eegclassify/clean.py
+# ------
+
+import logging
+from typing import List, Optional
+
+import pandas as pd
+import numpy as np
+from mne.filter import create_filter
+from scipy.signal import lfilter, lfilter_zi
+
+#from eegwatch.devices.base import _check_samples # this function is defined above instead
+
+logger = logging.getLogger(__name__)
+
+
+MAX_UV_ABS_DEFAULT = 400
+
+
+def clean(df: pd.DataFrame) -> pd.DataFrame:
+    # TODO: Add notch filters for 50Hz and 60Hz?
+    df = _clean_short(df)
+    df = _clean_duplicate_samples(df)
+    df = _clean_signal_quality(df)
+    df = _clean_inconsistent_sampling(df)
+    return df
+
+
+def filter(
+    X: np.ndarray,
+    sfreq: float = 250,
+    n_chans: int = 4,
+    low: float = 3,
+    high: float = 40,
+    verbose: bool = False 
+) -> np.ndarray:
+    """Inspired by viewer_v2.py in muse-lsl"""
+    window = 10
+    n_samples = int(sfreq * window)
+    data_f = np.zeros((n_samples, n_chans))
+
+    af = [1.0]
+    bf = create_filter(data_f.T, sfreq, low, high, method="fir",verbose=verbose)
+
+    zi = lfilter_zi(bf, af)
+    filt_state = np.tile(zi, (n_chans, 1)).transpose()
+    filt_samples, filt_state = lfilter(bf, af, X, axis=0, zi=filt_state)
+
+    return filt_samples
+
+
+def _clean_short(df: pd.DataFrame) -> pd.DataFrame:
+    sfreq = 250  # NOTE: Will be different for different devices
+    bads = []
+    for i, row in df.iterrows():
+        samples = len(row["raw_data"])
+        seconds = samples / sfreq
+        duration = row["stop"] - row["start"]
+        if seconds < 0.95 * duration.total_seconds():
+            # logger.warning(
+            #     f"Bad row found, only had {seconds}s of data out of {duration.total_seconds()}s"
+            # )
+            bads.append(i)
+
+    logger.warning(f"Dropping {len(bads)} rows due to missing samples")
+    return df.drop(bads)
+
+
+def _clean_duplicate_samples(df: pd.DataFrame) -> pd.DataFrame:
+    bads = []
+    for i, row in df.iterrows():
+        timestamps = [sample[0] for sample in row["raw_data"]]
+
+        # Check for duplicate timestamps
+        if len(timestamps) != len(set(timestamps)):
+            bads.append(i)
+
+    logger.warning(f"Dropping {len(bads)} bad rows due to duplicate samples")
+    return df.drop(bads)
+
+
+def _clean_inconsistent_sampling(df: pd.DataFrame) -> pd.DataFrame:
+    bads = []
+    for i, row in df.iterrows():
+        timestamps = [sample[0] for sample in row["raw_data"]]
+
+        # Check for consistent sampling
+        diffs = np.diff(timestamps)
+        if max(diffs) > 2 * min(diffs):
+            bads.append(i)
+
+    logger.warning(f"Dropping {len(bads)} bad rows due to inconsistent sampling")
+    return df.drop(bads)
+
+
+def _check_row_signal_quality(
+    s: pd.Series, max_uv_abs: float = MAX_UV_ABS_DEFAULT
+) -> bool:
+    """Takes a single row as input, returns true if good signal quality else false"""
+    # TODO: Improve quality detection
+    buffer = np.array([t[1:] for t in s["raw_data"]])  # strip timestamp
+    channels = [str(i) for i in range(buffer.size)]
+    return all(_check_samples(buffer, channels, max_uv_abs).values())
+
+
+def _row_stats(s: pd.Series):
+    buffer = np.array([t[1:] for t in s["raw_data"]])  # strip timestamp
+    return {
+        "min": np.min(np.abs(buffer), axis=0),
+        "max": np.max(np.abs(buffer), axis=0),
+        "ok": _check_row_signal_quality(s),
+    }
+
+
+def _clean_signal_quality(
+    df: pd.DataFrame, max_uv_abs: float = MAX_UV_ABS_DEFAULT
+) -> pd.DataFrame:
+    bads = []
+    for i, row in df.iterrows():
+        # print(_row_stats(row))
+        if not _check_row_signal_quality(row, max_uv_abs):
+            bads.append(i)
+
+    logger.warning(f"Dropping {len(bads)} bad rows due to bad signal quality")
+    return df.drop(bads)
+
+
+def test_clean_signal_quality():
+    df = pd.DataFrame(
+        [
+            {"raw_data": [[1, 100]]},
+            {"raw_data": [[1, 100]]},
+            {"raw_data": [[1, 300]]},
+        ]
+    )
+    df_clean = _clean_signal_quality(df, max_uv_abs=200)
+    assert len(df_clean) == 2
+
+
+def _select_classes(
+    df: pd.DataFrame,
+    col: str,
+    classes: List[str],
+) -> pd.DataFrame:
+    """
+    Removes rows that don't match the selected classes.
+    """
+    return df.loc[df[col].isin(classes), :]
+
+
+def test_select_classes():
+    df = pd.DataFrame({"class": ["a", "a", "b", "c"]})
+    df["class"] = df["class"].astype("category")
+    df = _select_classes(df, "class", ["a", "b"])
+    assert len(df) == 3
+
+
+def _remove_rare(
+    df: pd.DataFrame,
+    col: str,
+    threshold_perc: Optional[float] = None,
+    threshold_count: Optional[int] = None,
+) -> pd.DataFrame:
+    """
+    Removes rows with rare categories.
+
+    based on: https://stackoverflow.com/a/31502730/965332
+    """
+    if threshold_perc is None and threshold_count is None:
+        raise ValueError
+
+    logger.info(
+        f"Removing rare classes... (perc: {threshold_perc}, count: {threshold_count})"
+    )
+    if threshold_count is not None:
+        counts = df[col].value_counts()
+        df = df.loc[df[col].isin(counts[counts >= threshold_count].index), :]
+    if threshold_perc is not None:
+        counts = df[col].value_counts(normalize=True)
+        df = df.loc[df[col].isin(counts[counts >= threshold_perc].index), :]
+
+    return df
+
+
+def test_remove_rare():
+    df = pd.DataFrame({"class": ["a"] * 10 + ["b"] * 5 + ["c"] * 3 + ["d"] * 2})
+    df["class"] = df["class"].astype("category")
+
+    # Remove single class with percent
+    assert len(_remove_rare(df, "class", threshold_perc=0.15)) == 18
+
+    # Remove single class with count
+    assert len(_remove_rare(df, "class", threshold_count=3)) == 18
+
+    # Remove one class by count and one by percent
+    assert len(_remove_rare(df, "class", threshold_perc=0.2, threshold_count=3)) == 15
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -1,24 +1,30 @@
-from glob import glob
-import os
 import copy
 import math
+import logging
 from collections import OrderedDict
-from typing import Union, List
+from glob import glob
+from typing import Union, List, Dict
 
-from mne import create_info, concatenate_raws
-from mne.io import RawArray
-from mne.channels import make_standard_montage
 import pandas as pd
 import numpy as np
 import seaborn as sns
+from mne import create_info, concatenate_raws
+from mne.io import RawArray
+from mne.channels import make_standard_montage
+from mne.filter import create_filter
 from matplotlib import pyplot as plt
+from scipy.signal import lfilter, lfilter_zi
 
 from eegnb import _get_recording_dir
 from eegnb.devices.utils import EEG_INDICES, SAMPLE_FREQS
 
 
+# this should probably not be done here
 sns.set_context("talk")
 sns.set_style("white")
+
+
+logger = logging.getLogger(__name__)
 
 
 def load_csv_as_raw(
@@ -324,76 +330,19 @@ def plot_highlight_regions(
     return fig, axes
 
 
-
-
 # Bjareholt Tools
 # ==================
-
-
-# From     https://github.com/ErikBjare/thesis/blob/master/src/eegwatch/devices/base.py 
-# -------
-
-
-import logging
-from typing import List, Dict
-from abc import ABCMeta, abstractmethod
-
-import numpy as np
-
-
-logger = logging.getLogger(__name__)
-
-
-def _check_samples(
-    buffer: np.ndarray, channels: List[str], max_uv_abs=200
-) -> Dict[str, bool]:
-    # TODO: Better signal quality check
-    chmax = dict(zip(channels, np.max(np.abs(buffer), axis=0)))
-    return {ch: maxval < max_uv_abs for ch, maxval in chmax.items()}
-
-
-def test_check_samples():
-    buffer = np.array([[9.0, 11.0, -5, -13]])
-    assert {"TP9": True, "AF7": False, "AF8": True, "TP10": False} == _check_samples(
-        buffer, channels=["TP9", "AF7", "AF8", "TP10"], max_uv_abs=10
-    )
-
-
 # From    https://github.com/ErikBjare/thesis/blob/master/src/eegclassify/clean.py
 # ------
-
-import logging
-from typing import List, Optional
-
-import pandas as pd
-import numpy as np
-from mne.filter import create_filter
-from scipy.signal import lfilter, lfilter_zi
-
-#from eegwatch.devices.base import _check_samples # this function is defined above instead
-
-logger = logging.getLogger(__name__)
-
-
-MAX_UV_ABS_DEFAULT = 400
-
-
-def clean(df: pd.DataFrame) -> pd.DataFrame:
-    # TODO: Add notch filters for 50Hz and 60Hz?
-    df = _clean_short(df)
-    df = _clean_duplicate_samples(df)
-    df = _clean_signal_quality(df)
-    df = _clean_inconsistent_sampling(df)
-    return df
 
 
 def filter(
     X: np.ndarray,
-    sfreq: float = 250,
-    n_chans: int = 4,
+    n_chans: int,
+    sfreq: int,
     low: float = 3,
     high: float = 40,
-    verbose: bool = False 
+    verbose: bool = False,
 ) -> np.ndarray:
     """Inspired by viewer_v2.py in muse-lsl"""
     window = 10
@@ -401,173 +350,10 @@ def filter(
     data_f = np.zeros((n_samples, n_chans))
 
     af = [1.0]
-    bf = create_filter(data_f.T, sfreq, low, high, method="fir",verbose=verbose)
+    bf = create_filter(data_f.T, sfreq, low, high, method="fir", verbose=verbose)
 
     zi = lfilter_zi(bf, af)
     filt_state = np.tile(zi, (n_chans, 1)).transpose()
     filt_samples, filt_state = lfilter(bf, af, X, axis=0, zi=filt_state)
 
     return filt_samples
-
-
-def _clean_short(df: pd.DataFrame) -> pd.DataFrame:
-    sfreq = 250  # NOTE: Will be different for different devices
-    bads = []
-    for i, row in df.iterrows():
-        samples = len(row["raw_data"])
-        seconds = samples / sfreq
-        duration = row["stop"] - row["start"]
-        if seconds < 0.95 * duration.total_seconds():
-            # logger.warning(
-            #     f"Bad row found, only had {seconds}s of data out of {duration.total_seconds()}s"
-            # )
-            bads.append(i)
-
-    logger.warning(f"Dropping {len(bads)} rows due to missing samples")
-    return df.drop(bads)
-
-
-def _clean_duplicate_samples(df: pd.DataFrame) -> pd.DataFrame:
-    bads = []
-    for i, row in df.iterrows():
-        timestamps = [sample[0] for sample in row["raw_data"]]
-
-        # Check for duplicate timestamps
-        if len(timestamps) != len(set(timestamps)):
-            bads.append(i)
-
-    logger.warning(f"Dropping {len(bads)} bad rows due to duplicate samples")
-    return df.drop(bads)
-
-
-def _clean_inconsistent_sampling(df: pd.DataFrame) -> pd.DataFrame:
-    bads = []
-    for i, row in df.iterrows():
-        timestamps = [sample[0] for sample in row["raw_data"]]
-
-        # Check for consistent sampling
-        diffs = np.diff(timestamps)
-        if max(diffs) > 2 * min(diffs):
-            bads.append(i)
-
-    logger.warning(f"Dropping {len(bads)} bad rows due to inconsistent sampling")
-    return df.drop(bads)
-
-
-def _check_row_signal_quality(
-    s: pd.Series, max_uv_abs: float = MAX_UV_ABS_DEFAULT
-) -> bool:
-    """Takes a single row as input, returns true if good signal quality else false"""
-    # TODO: Improve quality detection
-    buffer = np.array([t[1:] for t in s["raw_data"]])  # strip timestamp
-    channels = [str(i) for i in range(buffer.size)]
-    return all(_check_samples(buffer, channels, max_uv_abs).values())
-
-
-def _row_stats(s: pd.Series):
-    buffer = np.array([t[1:] for t in s["raw_data"]])  # strip timestamp
-    return {
-        "min": np.min(np.abs(buffer), axis=0),
-        "max": np.max(np.abs(buffer), axis=0),
-        "ok": _check_row_signal_quality(s),
-    }
-
-
-def _clean_signal_quality(
-    df: pd.DataFrame, max_uv_abs: float = MAX_UV_ABS_DEFAULT
-) -> pd.DataFrame:
-    bads = []
-    for i, row in df.iterrows():
-        # print(_row_stats(row))
-        if not _check_row_signal_quality(row, max_uv_abs):
-            bads.append(i)
-
-    logger.warning(f"Dropping {len(bads)} bad rows due to bad signal quality")
-    return df.drop(bads)
-
-
-def test_clean_signal_quality():
-    df = pd.DataFrame(
-        [
-            {"raw_data": [[1, 100]]},
-            {"raw_data": [[1, 100]]},
-            {"raw_data": [[1, 300]]},
-        ]
-    )
-    df_clean = _clean_signal_quality(df, max_uv_abs=200)
-    assert len(df_clean) == 2
-
-
-def _select_classes(
-    df: pd.DataFrame,
-    col: str,
-    classes: List[str],
-) -> pd.DataFrame:
-    """
-    Removes rows that don't match the selected classes.
-    """
-    return df.loc[df[col].isin(classes), :]
-
-
-def test_select_classes():
-    df = pd.DataFrame({"class": ["a", "a", "b", "c"]})
-    df["class"] = df["class"].astype("category")
-    df = _select_classes(df, "class", ["a", "b"])
-    assert len(df) == 3
-
-
-def _remove_rare(
-    df: pd.DataFrame,
-    col: str,
-    threshold_perc: Optional[float] = None,
-    threshold_count: Optional[int] = None,
-) -> pd.DataFrame:
-    """
-    Removes rows with rare categories.
-
-    based on: https://stackoverflow.com/a/31502730/965332
-    """
-    if threshold_perc is None and threshold_count is None:
-        raise ValueError
-
-    logger.info(
-        f"Removing rare classes... (perc: {threshold_perc}, count: {threshold_count})"
-    )
-    if threshold_count is not None:
-        counts = df[col].value_counts()
-        df = df.loc[df[col].isin(counts[counts >= threshold_count].index), :]
-    if threshold_perc is not None:
-        counts = df[col].value_counts(normalize=True)
-        df = df.loc[df[col].isin(counts[counts >= threshold_perc].index), :]
-
-    return df
-
-
-def test_remove_rare():
-    df = pd.DataFrame({"class": ["a"] * 10 + ["b"] * 5 + ["c"] * 3 + ["d"] * 2})
-    df["class"] = df["class"].astype("category")
-
-    # Remove single class with percent
-    assert len(_remove_rare(df, "class", threshold_perc=0.15)) == 18
-
-    # Remove single class with count
-    assert len(_remove_rare(df, "class", threshold_count=3)) == 18
-
-    # Remove one class by count and one by percent
-    assert len(_remove_rare(df, "class", threshold_perc=0.2, threshold_count=3)) == 15
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -21,6 +21,8 @@ from pylsl import StreamInfo, StreamOutlet, StreamInlet, resolve_byprop
 
 from eegnb.devices.utils import get_openbci_usb, create_stim_array
 
+from eegnb.analysis.utils import filter,_check_samples
+
 # list of brainflow devices
 brainflow_devices = [
     "ganglion",
@@ -361,5 +363,50 @@ class EEG:
             df = self._muse_get_recent()
     
         return df
+
+
+
+
+    def check_sigquality(self,return_res=True,print_res=True,n_samples=500,n_times=1,pause_time=5):
+        """
+        Usage:
+        ------
+
+        from eegnb.devices.eeg import EEG
+        this_eeg = EEG(device='museS')
+
+        this_eeg.check_sigquality(n_times=5,pause_time=5)
+
+        """
+        
+
+
+        all_res,all_var = [],[]
+
+        for _ in range(n_times):
+
+            time.sleep(pause_time)
+
+            #df = self.get_recent()
+            df = self._muse_get_recent(max_samples=n_samples) # aim is to use the above command 
+            df_filt = filter(df.values)
+            df_filt = pd.DataFrame(df_filt.T,index=df.columns,columns=df.index.values).T
+
+            res = _check_samples(df_filt,df.columns)
+            var = df_filt.var(axis=0)
+
+            if print_res:
+                print("\n\nSignal Quality check: ")
+                print(res)
+
+                print('variance:')
+                print(var)
+
+            all_res.append(res)
+            all_var.append(var)
+
+        if return_res:
+            return all_res,all_var
+
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,9 @@ pytest
 pytest-cov
 nbval
 
+# Types
+types-requests
+
 # Docs requirements
 sphinx==3.1.1
 sphinx-gallery==0.8.1


### PR DESCRIPTION
A discussed previously, added a load of code from Bjareholt thesis repo to `eegnb.analysis.utils.py`, and also a new method calling this for buffered samples in `eegnb.devices.eeg.py`. 

For usage, see the new `check_sigquality` method docstring `eegnb.devices.eeg.py`


```python  
from eegnb.devices.eeg import EEG                                                                                                     
this_eeg = EEG(device='museS')                               
                                                                                                                                                                                                               this_eeg.check_sigquality(n_times=5,pause_time=5)
```

Runs in a loop `n_times`, and prints the signal variance and boolean output of EB's check signal quality method, based on absolute amplitude thresholds (which might also need modifying?). Includes a pause of `pause_time` duration, to allow for adjustment etc. 


Notes: 

- A lot of the added EB code doesn't work, and not sure exactly what it' doing. The thinking was to add all the stuff first and then remove what we don't need, rather than bit-part add in. 
- As with the recently added `get_recent` code, this is still muse device specific
- Main thing to do next is improve the command line outputs and decide what the most useful usage model would be


