### PR TITLE
Minor CLI code & docs update

### DIFF
--- a/doc/getting_started/running_experiments.md
+++ b/doc/getting_started/running_experiments.md
@@ -4,13 +4,18 @@ After you have installed the library there are two methods for collecting data. 
 ## Command Line Interface
 To activate the command line tool, open a command/terminal prompt and enter `eegnb runexp` followed by the appropriate flags for your device, desired experiment, and more. The possible flags are
 * *-ed ; --eegdevice*: The device being used to record data. Each device has a specific string to be passed which can be seen on the [Initiating an EEG Stream](https://neurotechx.github.io/eeg-notebooks/getting_started/streaming.html) under the `EEG.device` parameter for the respective device.
-* *-ex ; --expt*: The experiment to be run 
+* *-ex ; --experiment*: The experiment to be run
+* *-ma ; --macaddr*: The MAC address of device to use (applicable devices e.g ganglion)
 * *-rd ; --recdur*: Duration of recording (in seconds).
-* *-of ; -outfname*: Save file name (this will be automatically generated to match default file system if left blank).
-* *-ip ; --inprom*: Bypass the other flags to activate an interactive prompt.
+* *-of ; --outfname*: Save file name (this will be automatically generated to match default file system if left blank).
+* *-ip ; --prompt*: Bypass the other flags to activate an interactive prompt.
 
 ### Using the introprompt flag
 If using the `-ip` flag the user will be prompted to input the various session parameters. The prompts are detailed below.
+
+```
+eegnb runexp -ip
+```
 
 #### Board Selection
 ```
@@ -35,9 +40,9 @@ Here you specify which of the supported boards you are using to collect data. EE
 #### Experiment Selection
 ```
 Please select which experiment you would like to run: 
-[0] visual n170 
-[1] visual p300 
-[2] ssvep 
+[0] Visual N170
+[1] Visual P300
+[2] Visual SSVEP
 
 Enter Experiment Selection:
 ```

--- a/eegnb/cli/__main__.py
+++ b/eegnb/cli/__main__.py
@@ -8,12 +8,7 @@ def main():
 
 
 @main.command()
-@click.option(
-    "-ex",
-    "--experiment",
-    help="Experiment to run",
-    prompt="Experiment to run",
-)
+@click.option("-ex", "--experiment", help="Experiment to run")
 @click.option("-ed", "--eegdevice", help="EEG device to use")
 @click.option("-ma", "--macaddr", help="MAC address of device to use (if applicable)")
 @click.option("-rd", "--recdur", help="Recording duration", type=float)
@@ -22,7 +17,7 @@ def main():
     "-ip", "--prompt", help="Use interactive prompt to ask for parameters", is_flag=True
 )
 def runexp(
-    experiment: str,
+    experiment: str = None,
     eegdevice: str = None,
     macaddr: str = None,
     recdur: float = None,
@@ -39,7 +34,7 @@ def runexp(
     This is the quickest way to run eeg-notebooks experiments,
     but requires knowledge of formatting for available options
 
-    $ eegnb runexp -ed museS -ex visual-N170 -rd 10 -of test.csv
+    $ eegnb runexp -ex visual-N170 -ed museS -rd 10 -of test.csv
 
 
     Launch the interactive command line experiment setup+run tool
@@ -49,7 +44,7 @@ def runexp(
     $ eegnb runexp -ip
     """
     if prompt:
-        print("run command line prompt script")
+        #import and run the introprompt script
         from .introprompt import main as run_introprompt
 
         run_introprompt()
@@ -64,26 +59,6 @@ def runexp(
             eeg = EEG(device=eegdevice)
 
         run_experiment(experiment, eeg, recdur, outfname)
-
-
-@main.command()
-@click.option("-ed", "--eegdevice", help="EEG device to use")
-@click.option("-vr", "--version", help="Viewer version (for muselsl)")
-def view():
-    """
-    View live EEG stream.
-
-    Examples: TODO
-    """
-    print("add viewer functionality here")
-
-    # args = parser.parse_args(sys.argv[2:])
-    # from . import view
-    # view(args.window, args.scale, args.refresh,
-    #     args.figure, args.version, args.backend)
-
-    raise NotImplementedError
-
 
 if __name__ == "__main__":
     main()

--- a/eegnb/cli/__main__.py
+++ b/eegnb/cli/__main__.py
@@ -17,7 +17,7 @@ def main():
     "-ip", "--prompt", help="Use interactive prompt to ask for parameters", is_flag=True
 )
 def runexp(
-    experiment: str = None,
+    experiment: str,
     eegdevice: str = None,
     macaddr: str = None,
     recdur: float = None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,10 @@ dataclasses; python_version == '3.6'
 pywinhook>=1.6.0 ; platform_system == "Windows" and (python_version == "3.7" or python_version == "3.8")
 pywinhook @ https://github.com/ActivityWatch/wheels/raw/master/pywinhook/pyWinhook-1.6.2-cp39-cp39-win_amd64.whl ; platform_system == "Windows" and python_version == "3.9"
 
+# pyglet downgrade to prevent threadmode warning on windows
+# See issue: https://github.com/psychopy/psychopy/issues/2876
+pyglet==1.4.10 ; platform_system == "Windows"
+
 # Test requirements
 mypy
 pytest


### PR DESCRIPTION
- Removes the "prompt" parameter from the `-ex` option: previous setting was forcing user to enter a value even when `-ip` was passed
- Minor cli script cleanup
- Updates CLI documentation
- Downgrades pyglet version on windows to remove thread warning error