### PR TITLE
Fix musedevicenotrec

### DIFF
--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -8,7 +8,7 @@ from .utils import run_experiment, get_exp_desc, experiments
 
 
 def device_prompt() -> EEG:
-    # define the names of the available boards
+    # define the names of the available devices  ( / 'boards' ) 
     # boards is a mapping from board code to board description
     boards = {
         "none": "None",
@@ -30,13 +30,13 @@ def device_prompt() -> EEG:
     print("Please enter the integer value corresponding to your EEG device: \n")
     print("\n".join(f"[{i:2}] {board}" for i, board in enumerate(boards.values())))
 
-    board_idx = int(input("\nEnter Board Selection: "))
+    board_idx = int(input("\nEnter Device Selection: "))
 
     # Board_codes are the actual names to be passed to the EEG class
     board_code = list(boards.keys())[board_idx]
     board_desc = list(boards.values())[board_idx]
 
-    print(f"Selected board: {board_desc} \n")
+    print(f"Selected device: {board_desc} \n")
 
     # Handles connectivity selection if an OpenBCI board is being used
     if board_code in ["cyton", "cyton_daisy", "ganglion"]:

--- a/eegnb/devices/utils.py
+++ b/eegnb/devices/utils.py
@@ -6,8 +6,11 @@ import serial
 from brainflow import BoardShim, BoardIds
 
 
-# Default channel names for the various brainflow devices.
+# Default channel names for the various EEG devices.
 EEG_CHANNELS = {
+    "muse2016": ['TP9', 'AF7', 'AF8', 'TP10', 'Right AUX'],
+    "muse2": ['TP9', 'AF7', 'AF8', 'TP10', 'Right AUX'],
+    "museS": ['TP9', 'AF7', 'AF8', 'TP10', 'Right AUX'],
     "ganglion": ["fp1", "fp2", "tp7", "tp8"],
     "cyton": BoardShim.get_eeg_names(BoardIds.CYTON_BOARD.value),
     "cyton_daisy": BoardShim.get_eeg_names(BoardIds.CYTON_DAISY_BOARD.value),


### PR DESCRIPTION

At some point (recently?) the CLI for muse devices was broken, because muse devices weren't included in the 'boards' lists. 

Simple fix here. 

