### PR TITLE
add requirement for docutils==0.17, to fix CI doc build issue (?)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ numpydoc==1.1.0
 recommonmark==0.6.0
 versioneer==0.19
 rst2pdf==0.98
+docutils==0.17


### PR DESCRIPTION

CI has a strange error right now, don't understand why. Seeing if this `docutils` version fixing solves it. 

 