### PR TITLE
fixed data_dir parameter to not only use default value.

### DIFF
--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -149,7 +149,7 @@ def load_data(
         site = "*"
 
     data_path = (
-        _get_recording_dir(device_name, experiment, subject_str, session_str, site)
+        _get_recording_dir(device_name, experiment, subject_str, session_str, site, data_dir)
         / "*.csv"
     )
     fnames = glob(str(data_path))


### PR DESCRIPTION
I tried altering the path to load the data from my desktop but it didn't work, turned out that the parameter was being ignored and was just falling back to the default DATA_DIR with a value of ~/.eegnb/data