### PR TITLE
automatically cue signal quality check when running experiments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         python_version: [3.7]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             python_version: 3.8
           # Experimental: Python 3.9
           # See issue: https://github.com/NeuroTechX/eeg-notebooks/issues/50

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -410,7 +410,7 @@ def check(eeg: EEG, n_samples=256, std_thres=15):
 
 
 
-def check_report(eeg, n_times: int=60, pause_time=5, thres_std=10,n_goods=2):
+def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std=10,n_goods=2):
     """
     Usage:
     ------

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -4,7 +4,8 @@ import logging
 from collections import OrderedDict
 from glob import glob
 from typing import Union, List, Dict
-from time import sleep
+from time import sleep, time
+from numpy.core.fromnumeric import std
 
 import pandas as pd
 import numpy as np
@@ -338,7 +339,7 @@ def plot_highlight_regions(
 # ------
 
 
-def filter(
+def channel_filter(
     X: np.ndarray,
     n_chans: int,
     sfreq: int,
@@ -369,7 +370,7 @@ def filter(
     return filt_samples
 
 
-def check(eeg: EEG, n_samples=256, std_thres=15):
+def check(eeg: EEG, n_samples=256) -> pd.Series:
     """
     Usage:
     ------
@@ -378,15 +379,6 @@ def check(eeg: EEG, n_samples=256, std_thres=15):
     from eegnb.analysis.utils import check
     eeg = EEG(device='museS')
     check(eeg, n_samples=256)
-
-    The std_thres value is the upper bound of accepted
-    standard deviation for a quality recording.
-
-    thresholds = {
-        bad: 15,
-        good: 10,
-        great: 1.5 // Below 1.5 usually indicates not connected to anything
-    }
 
     """
 
@@ -398,19 +390,18 @@ def check(eeg: EEG, n_samples=256, std_thres=15):
     device_backend = eeg.backend
 
     vals = df.values[:, :n_channels]
-    df.values[:, :n_channels] = filter(vals, 
+    df.values[:, :n_channels] = channel_filter(vals, 
                                     n_channels,
                                     sfreq,
                                     device_backend)
 
-    std = df.std(axis=0)
-    res = dict(zip(df.columns[:n_channels], std < std_thres))
+    std_series = df.std(axis=0)
     
-    return res, std
+    return std_series
 
 
 
-def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std=10,n_goods=2):
+def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=1, thres_std_high=15, n_goods=2):
     """
     Usage:
     ------
@@ -418,10 +409,20 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std=10,n_goods=2
     from eegnb.analysis.utils import check_report
     eeg = EEG(device='museS')
     check_report(eeg)
+
+    The thres_std_low & thres_std_high values are the 
+    lower and  upper bound of accepted
+    standard deviation for a quality recording.
+
+    thresholds = {
+        bad: 15,
+        good: 10,
+        great: 1.5 // Below 1 usually indicates not connected to anything
+    }
     """
 
     print("\n\nRunning signal quality check...")
-    print(f"Using threshold stdev: {thres_std}")
+    print(f"Accepting threshold stdev between: {thres_std_low} - {thres_std_high}")
 
     CHECKMARK = "√"
     CROSS = "x"
@@ -432,21 +433,21 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std=10,n_goods=2
     good_count=0
 
     n_samples = int(pause_time*eeg.sfreq)
-    for _ in range(n_times):
-        print(f'\n\n\n{_+1}/{n_times}')
-        res, std = check(eeg, n_samples=n_samples)
+    for loop_index in range(n_times):
+        print(f'\n\n\n{loop_index+1}/{n_times}')
+        std_series = check(eeg, n_samples=n_samples)
 
         indicators = "\n".join(
         [
-            f"  {k:>4}: {CHECKMARK if v else CROSS}   (std: {round(std[k], 1):>5})"
-                for k, v in res.items()
+            f"  {k:>4}: {CHECKMARK if v >= thres_std_low and v <= thres_std_high else CROSS}  (std: {round(v, 1):>5})"
+                for k, v in std_series.iteritems()
         ]
                               )
         print("\nSignal quality:")
         print(indicators)
 
         
-        bad_channels = [k for k, v in res.items() if not v]
+        bad_channels = [k for k, v in std_series.iteritems() if v < thres_std_low or v > thres_std_high ]
         if bad_channels:
             print(f"Bad channels: {', '.join(bad_channels)}")
             good_count=0  # reset good checks count if there are any bad chans
@@ -458,7 +459,17 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std=10,n_goods=2
             print("\n\n\nAll good! You can proceed on to data collection :) ")
             break
 
+        # after every 5 trials ask user if they want to cancel or continue
+        if (loop_index+1) % 5 == 0:
+            print(f"\n\nLooks like you still have {len(bad_channels)} bad channels after {loop_index+1} tries\n")
+
+            prompt_start = time()
+            continue_sigqual = input("\nChecks will resume in 10 seconds...Press 'c' (and ENTER key) if you want to stop adjusting for better quality.\n")
+            while time() < prompt_start + 5:
+                if continue_sigqual == 'c':
+                    break
+            if continue_sigqual == 'c':
+                print("\nStopping signal quality checks!")
+                break
+        
         sleep(pause_time)
-
-
-

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -401,7 +401,7 @@ def check(eeg: EEG, n_samples=256) -> pd.Series:
 
 
 
-def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=1, thres_std_high=15, n_goods=2):
+def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=1, thres_std_high=15, n_goods=2,n_inarow=10):
     """
     Usage:
     ------
@@ -459,8 +459,8 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=1, thres
             print("\n\n\nAll good! You can proceed on to data collection :) ")
             break
 
-        # after every 5 trials ask user if they want to cancel or continue
-        if (loop_index+1) % 5 == 0:
+        # after every n_inarow trials ask user if they want to cancel or continue
+        if (loop_index+1) % n_inarow == 0:
             print(f"\n\nLooks like you still have {len(bad_channels)} bad channels after {loop_index+1} tries\n")
 
             prompt_start = time()

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -401,7 +401,7 @@ def check(eeg: EEG, n_samples=256) -> pd.Series:
 
 
 
-def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=1, thres_std_high=15, n_goods=2,n_inarow=10):
+def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=None, thres_std_high=None, n_goods=2,n_inarow=10):
     """
     Usage:
     ------
@@ -421,16 +421,25 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=1, thres
     }
     """
 
-    # set upper threshold based on device name
-    if eeg.device_name in ["ganglion", "ganglion_wifi", "cyton",
+    # If no upper and lower std thresholds set in function call,
+    # set thresholds based on the following per-device name defaults
+    if thres_std_high is None:
+        if eeg.device_name in ["ganglion", "ganglion_wifi", "cyton",
                     "cyton_wifi", "cyton_daisy", "cyton_daisy_wifi"]:
-        thres_std_high = 9
-    elif eeg.device_name in ["notion1", "notion2", "crowm"]:
-        thres_std_high = 15
-    elif eeg.device_name in ["muse2016", "muse2", "museS"]:
-        thres_std_high = 18
+            thres_std_high = 9
+        elif eeg.device_name in ["notion1", "notion2", "crown"]:
+            thres_std_high = 15
+        elif eeg.device_name in ["muse2016", "muse2", "museS"]:
+            thres_std_high = 18
 
+    if thres_std_low is None:
+        if eeg.device_name in ["ganglion", "ganglion_wifi", "cyton",
+                               "cyton_wifi", "cyton_daisy", "cyton_daisy_wifi",
+                               "notion1", "notion2", "crown",
+                               "muse2016", "muse2", "museS"]:
+            thres_std_low = 1
 
+            
     print("\n\nRunning signal quality check...")
     print(f"Accepting threshold stdev between: {thres_std_low} - {thres_std_high}")
 

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -421,6 +421,16 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=1, thres
     }
     """
 
+    # set upper threshold based on device name
+    if eeg.device_name in ["ganglion", "ganglion_wifi", "cyton",
+                    "cyton_wifi", "cyton_daisy", "cyton_daisy_wifi"]:
+        thres_std_high = 9
+    elif eeg.device_name in ["notion1", "notion2", "crowm"]:
+        thres_std_high = 15
+    elif eeg.device_name in ["muse2016", "muse2", "museS"]:
+        thres_std_high = 18
+
+
     print("\n\nRunning signal quality check...")
     print(f"Accepting threshold stdev between: {thres_std_low} - {thres_std_high}")
 

--- a/eegnb/cli/__main__.py
+++ b/eegnb/cli/__main__.py
@@ -56,27 +56,25 @@ def runexp(
     $ eegnb runexp -ip
     """
 
-    #from .introprompt import intro_prompt
-    #from .utils import run_experiment
-    #from eegnb.devices.eeg import EEG
-    #from eegnb.analysis.utils import check_report 
-
     if prompt:
-        eeg_deviceargs, experiment, recdur, outfname = intro_prompt()
+        eeg, experiment, recdur, outfname = intro_prompt()
     else:
-        eeg_deviceargs = {'device': eegdevice, 'mac_addr': macaddr} 
-
-    eeg = EEG(**eeg_deviceargs)
-    print("\nEEG device successfully connected!")
+        if eegdevice == "ganglion":
+            # if the ganglion is chosen a MAC address should also be proviced
+            eeg = EEG(device=eegdevice, mac_addr=macaddr)
+        else:
+            eeg = EEG(device=eegdevice)
+        print("\nEEG device successfully connected!")
 
 
     def askforsigqualcheck():
-        doit = input("Run signal quality check? (y/n). Recommend y \n")
-        if doit == 'y':
+        do_sigqual = input("Run signal quality check? (y/n). Recommend y \n")
+        if do_sigqual == 'y':
             check_report(eeg)
-        elif doit != 'n':
+        elif do_sigqual != 'n':
             "sorry, didn't recognize answer. "
             askforsigqualcheck()
+    
     if dosigqualcheck:
         askforsigqualcheck()
 

--- a/eegnb/cli/__main__.py
+++ b/eegnb/cli/__main__.py
@@ -60,19 +60,17 @@ def runexp(
         eeg, experiment, recdur, outfname = intro_prompt()
     else:
         if eegdevice == "ganglion":
-            # if the ganglion is chosen a MAC address should also be proviced
+            # if the ganglion is chosen a MAC address should also be provided
             eeg = EEG(device=eegdevice, mac_addr=macaddr)
         else:
             eeg = EEG(device=eegdevice)
-        print("\nEEG device successfully connected!")
-
 
     def askforsigqualcheck():
-        do_sigqual = input("Run signal quality check? (y/n). Recommend y \n")
+        do_sigqual = input("\n\nRun signal quality check? (y/n). Recommend y \n")
         if do_sigqual == 'y':
             check_report(eeg)
         elif do_sigqual != 'n':
-            "sorry, didn't recognize answer. "
+            "Sorry, didn't recognize answer. "
             askforsigqualcheck()
     
     if dosigqualcheck:
@@ -80,6 +78,8 @@ def runexp(
 
 
     run_experiment(experiment, eeg, recdur, outfname)
+
+    print(f"\n\n\nExperiment complete! Recorded data is saved @ {outfname}")
 
 
 

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -116,7 +116,7 @@ def site_prompt(experiment:str) -> str:
     print("Selected Folder : {} \n".format(site))
     return site
 
-def intro_prompt() -> Tuple[EEG, str, int, Path]:
+def intro_prompt() -> Tuple[EEG, str, int, str]:
     """This function handles the user prompts for inputting information about the session they wish to record."""
     print("Welcome to NeurotechX EEG Notebooks\n")
 
@@ -147,7 +147,7 @@ def intro_prompt() -> Tuple[EEG, str, int, Path]:
         eeg_device.device_name, exp_selection, subj_id, session_nb 
     )
 
-    return eeg_device, exp_selection, duration, save_fn
+    return eeg_device, exp_selection, duration, str(save_fn)
 
 
 def intro_prompt_zip() -> Tuple[str,str]:

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -1,5 +1,5 @@
 import os 
-from typing import Tuple, Union
+from typing import Tuple
 from pathlib import Path
 
 from eegnb import generate_save_fn, DATA_DIR
@@ -7,7 +7,7 @@ from eegnb.devices.eeg import EEG
 from .utils import run_experiment, get_exp_desc, experiments
 
 
-def device_prompt(returndeviceobj=False) -> Union[dict,EEG]: 
+def device_prompt() -> EEG: 
     # define the names of the available boards
     # boards is a mapping from board code to board description
     boards = {
@@ -65,21 +65,16 @@ def device_prompt(returndeviceobj=False) -> Union[dict,EEG]:
                 f"\n{board_desc} + WiFi is not supported. Please use the dongle that was shipped with the device.\n"
             )
             exit()
-
-
-    eeg_deviceargs = {'device': board_code}
        
     if board_code.startswith("ganglion"):
         if board_code == "ganglion_wifi":
-            eeg_deviceargs['ip_addr'] = ip_address
+            eeg_device = EEG(device=board_code, ip_addr=ip_address)
         else:
-            eeg_deviceargs['mac_addr'] = ganglion_mac_address
-   
-    if returndeviceobj:
-        eeg_device = EEG(**eeg_deviceargs)
-        return eeg_device
+            eeg_device = EEG(device=board_code, mac_addr=ganglion_mac_address)
     else:
-        return eeg_deviceargs
+        eeg_device = EEG(device=board_code)
+
+    return eeg_device
 
 
 
@@ -121,13 +116,12 @@ def site_prompt(experiment:str) -> str:
     print("Selected Folder : {} \n".format(site))
     return site
 
-def intro_prompt() -> Union[ Tuple[dict, str, int, Path], Tuple[EEG, str, int, Path] ]:
+def intro_prompt() -> Tuple[EEG, str, int, Path]:
     """This function handles the user prompts for inputting information about the session they wish to record."""
     print("Welcome to NeurotechX EEG Notebooks\n")
 
     # ask the user which device to use
-    #eeg_device = device_prompt()
-    eeg_deviceargs = device_prompt() 
+    eeg_device = device_prompt()
 
     # ask the user which experiment to run
     exp_selection = exp_prompt()
@@ -150,11 +144,10 @@ def intro_prompt() -> Union[ Tuple[dict, str, int, Path], Tuple[EEG, str, int, P
 
     # generate the save file name
     save_fn = generate_save_fn(
-        eeg_deviceargs['device'], exp_selection, subj_id, session_nb # eeg_device.device_name, exp_selection, subj_id, session_nb 
-        )
+        eeg_device.device_name, exp_selection, subj_id, session_nb 
+    )
 
-    #return eeg_device, exp_selection, duration, save_fn
-    return eeg_deviceargs, exp_selection, duration, save_fn
+    return eeg_device, exp_selection, duration, save_fn
 
 
 def intro_prompt_zip() -> Tuple[str,str]:

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -1,5 +1,5 @@
 import os 
-from typing import Tuple
+from typing import Tuple, Union
 from pathlib import Path
 
 from eegnb import generate_save_fn, DATA_DIR
@@ -7,7 +7,7 @@ from eegnb.devices.eeg import EEG
 from .utils import run_experiment, get_exp_desc, experiments
 
 
-def device_prompt(returndeviceobj=False) -> dict or EEG : 
+def device_prompt(returndeviceobj=False) -> Union[dict,EEG]: 
     # define the names of the available boards
     # boards is a mapping from board code to board description
     boards = {
@@ -121,7 +121,7 @@ def site_prompt(experiment:str) -> str:
     print("Selected Folder : {} \n".format(site))
     return site
 
-def intro_prompt() -> Tuple[dict, str, int, Path] or Tuple[EEG, str, int, Path]:
+def intro_prompt() -> Union[ Tuple[dict, str, int, Path], Tuple[EEG, str, int, Path] ]:
     """This function handles the user prompts for inputting information about the session they wish to record."""
     print("Welcome to NeurotechX EEG Notebooks\n")
 

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -7,7 +7,7 @@ from eegnb.devices.eeg import EEG
 from .utils import run_experiment, get_exp_desc, experiments
 
 
-def device_prompt() -> EEG:
+def device_prompt(returndeviceobj=False) -> dict or EEG : 
     # define the names of the available boards
     # boards is a mapping from board code to board description
     boards = {
@@ -66,16 +66,21 @@ def device_prompt() -> EEG:
             )
             exit()
 
-    # initialize the EEG device
+
+    eeg_deviceargs = {'device': board_code}
+       
     if board_code.startswith("ganglion"):
         if board_code == "ganglion_wifi":
-            eeg_device = EEG(device=board_code, ip_addr=ip_address)
+            eeg_deviceargs['ip_addr'] = ip_address
         else:
-            eeg_device = EEG(device=board_code, mac_addr=ganglion_mac_address)
+            eeg_deviceargs['mac_addr'] = ganglion_mac_address
+   
+    if returndeviceobj:
+        eeg_device = EEG(**eeg_deviceargs)
+        return eeg_device
     else:
-        eeg_device = EEG(device=board_code)
+        return eeg_deviceargs
 
-    return eeg_device
 
 
 def exp_prompt() -> str:
@@ -116,12 +121,13 @@ def site_prompt(experiment:str) -> str:
     print("Selected Folder : {} \n".format(site))
     return site
 
-def intro_prompt() -> Tuple[EEG, str, int, Path]:
+def intro_prompt() -> Tuple[dict, str, int, Path] or Tuple[EEG, str, int, Path]:
     """This function handles the user prompts for inputting information about the session they wish to record."""
     print("Welcome to NeurotechX EEG Notebooks\n")
 
     # ask the user which device to use
-    eeg_device = device_prompt()
+    #eeg_device = device_prompt()
+    eeg_deviceargs = device_prompt() 
 
     # ask the user which experiment to run
     exp_selection = exp_prompt()
@@ -139,15 +145,17 @@ def intro_prompt() -> Tuple[EEG, str, int, Path]:
     session_nb = int(input("Enter session #: "))
 
     # ask if they are ready to begin
-    print("\nEEG device successfully connected!")
-    input("Press [ENTER] when ready to begin...")
+    #print("\nEEG device successfully connected!")
+    #input("Press [ENTER] when ready to begin...")
 
     # generate the save file name
     save_fn = generate_save_fn(
-        eeg_device.device_name, exp_selection, subj_id, session_nb
-    )
+        eeg_deviceargs['device'], exp_selection, subj_id, session_nb # eeg_device.device_name, exp_selection, subj_id, session_nb 
+        )
 
-    return eeg_device, exp_selection, duration, save_fn
+    #return eeg_device, exp_selection, duration, save_fn
+    return eeg_deviceargs, exp_selection, duration, save_fn
+
 
 def intro_prompt_zip() -> Tuple[str,str]:
     """This function handles the user prompts for inputting information for zipping their function."""

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -269,8 +269,13 @@ class EEG:
             self.board.start_stream()
         
         self.stream_started = True
+
         # wait for signal to settle
-        sleep(5)
+        if (self.device_name.find("cyton") != -1) or (self.device_name.find("ganglion") != -1):
+            # wait longer for openbci cyton / ganglion
+            sleep(10)
+        else:
+            sleep(5)
 
     def _stop_brainflow(self):
         """This functions kills the brainflow backend and saves the data to a CSV file."""

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -264,7 +264,10 @@ class EEG:
         self.board.prepare_session()
 
     def _start_brainflow(self):
-        self.board.start_stream()
+        # only start stream if non exists
+        if not self.stream_started:
+            self.board.start_stream()
+        
         self.stream_started = True
         # wait for signal to settle
         sleep(5)
@@ -333,15 +336,14 @@ class EEG:
         self.markers.append([marker, last_timestamp])
 
 
-    def _brainflow_get_recent(self, n_samples=256, restart_stream=False):
+    def _brainflow_get_recent(self, n_samples=256):
 
         # initialize brainflow if not set
         if self.board == None:
             self._init_brainflow()
 
-        # start brainflow stream if none exists or explicity requested
-        if ( not self.stream_started ) or restart_stream:
-            self._start_brainflow()
+        # start branflow stream
+        self._start_brainflow()
 
         # get the latest data
         data = self.board.get_current_board_data(n_samples)

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -9,12 +9,13 @@ from pandas import DataFrame
 from psychopy import visual, core, event
 
 from eegnb import generate_save_fn
+from eegnb.devices.eeg import EEG
 from eegnb.stimuli import FACE_HOUSE
 
 __title__ = "Visual N170"
 
 
-def present(duration=120, eeg=None, save_fn=None):
+def present(duration=120, eeg: EEG=None, save_fn=None):
     n_trials = 2010
     iti = 0.4
     soa = 0.3

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -3,6 +3,7 @@ from time import time
 from glob import glob
 from random import choice
 from optparse import OptionParser
+import random
 
 import numpy as np
 from pandas import DataFrame
@@ -44,7 +45,8 @@ def present(duration=120, eeg: EEG=None, save_fn=None):
 
     if eeg:
         if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
-            save_fn = generate_save_fn(eeg.device_name, "visual_n170", "unnamed")
+            random_id = random.randint(1000,10000)
+            save_fn = generate_save_fn(eeg.device_name, "visual_n170", random_id, random_id, "unnamed")
             print(
                 f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
             )


### PR DESCRIPTION
Added functionality to automatically initiate signal quality check when running experiments. 

The `check_report` command line program is executed immediately before the `run_experiment` command. When the interactive experiment prompt selection is called by `eegnb runexp -ip`, the signal quality check prompt appears immediately after the initial experiment and device selections, and immediately before the start of the experiment. 

In the process of doing this, this PR also includes a bit of rationalization of functions from the `introprompt.py` and `__main__.py` functions in the `cli` folder. Specifically, the EEG device object creation is (as default behaviour) moved out of the intro prompt command and intro the main function. This was necessary here because the EEG object also needs to be created for the signal quality check, so the reorganization avoids those commands being called twice in two separate places. 

Checked for muse. Seems to be working ok. Also needs testing for Neurosity and OpenBCI. 

Perhaps could be some small improvements in the command line messages. 

