### PR TITLE
sqc fixes for unicorn

### DIFF
--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -22,7 +22,7 @@ def device_prompt() -> EEG:
         "ganglion": "OpenBCI Ganglion",
         "cyton": "OpenBCI Cyton",
         "cyton_daisy": "OpenBCI Cyton + Daisy",
-        "unicord": "G.Tec Unicorn",
+        "unicorn": "G.Tec Unicorn",
         "brainbit": "BrainBit",
         "notion1": "Notion 1",
         "notion2": "Notion 2",


### PR DESCRIPTION

Put in some candidate numbers for stdev thresholds for unicorn. Exact numbers to be revised upon further experience with the device. Now, at least, the cli sigqual check and experiment runner works. 

Note that unicorn usage here requires a third-party software from the manufacturers for initiation of a stream ('unicorn suite hybrid black'). This is a minimal GUI that functions similarly to BlueMuse. The key difference from BlueMuse is that the unicorn suite works with + is necessary for brainflow-based streaming, whereas BlueMuse works with muselsl. Note that the unicorn suite required is not the unicorn Python API, which is an additional software purchase for the cost of (~$400). I do not have the Python API library and don't know anything about it; brainflow compatibility is all we need. 

Initial impressions are that ERPs from the unicorn are very good. Montage is a little different from OpenBCI and Muse (no TP chans, concentrated more around occipital). Will add data to the demo set soon. 

Interestingly the electrodes are designed to allow both dry and wet recordings. First testing was done dry, will be giving it a spin with gel next. Interested to see how much better it gets. 



