### PR TITLE
Experiment class refactor 

### DIFF
--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -18,32 +18,46 @@ called according to the stage of the cycle
 
 class Experiment:
 
-    def __init_():
+    def __init_(self):
+        
+        # Should have overwriting property for different experiments
+        self.instruction_text = """\nWelcome to the {} experiment!\nStay still, focus on the centre of the screen, and try not to blink. \nThis block will run for %s seconds.\n
+        Press spacebar to continue. \n""".format(exp_name) 
+  
+    
+    def setup(self):
 
-
-    def present(duration=120, eeg: EEG=None, save_fn=None, n_trials=2010, exp_name=""):
-        """ Do the present operation for a bunch of experiments """
-      
-        # Setup Trial list -> Common in most
-        parameter = np.random.binomial(1, 0.5, n_trials)
-        trials = DataFrame(dict(parameter=parameter, timestamp=np.zeros(n_trials)))
+        # Setup Trial list -> Common in most (csv in Unicorn)
+        self.parameter = np.random.binomial(1, 0.5, n_trials)
+        self.trials = DataFrame(dict(parameter=parameter, timestamp=np.zeros(n_trials)))
 
         # Setup Graphics 
         mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True) 
         """ Does specific thing within Experiment Type to load stimulus data """
-
+        
+        # Needs to be overwritten by specific experiment
+        self.stim = self.load_stimulus()
+        
         # Show Instruction Screen
-        show_instructions(duration=duration)
+        self.show_instructions(duration=duration)
 
-        # Start EEG Stream, wait for signal to settle, and then pull timestamp for start point
-        if eeg:
-        if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
+        # Establish save function
+        if self.save_fn is None:  # If no save_fn passed, generate a new unnamed save file
             random_id = random.randint(1000,10000)
-            save_fn = generate_save_fn(eeg.device_name, "visual_n170", random_id, random_id, "unnamed")
+            self.save_fn = generate_save_fn(eeg.device_name, experiement_id, random_id, random_id, "unnamed")
             print(
                 f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
             )
-        eeg.start(save_fn, duration=record_duration + 5)
+                
+
+    
+    def present(self, duration=120, eeg: EEG=None, save_fn=None, n_trials=2010, exp_name=""):
+        """ Do the present operation for a bunch of experiments """
+      
+    
+        # Start EEG Stream, wait for signal to settle, and then pull timestamp for start point
+        if eeg:
+            eeg.start(save_fn, duration=record_duration + 5)
 
         start = time()
         
@@ -75,9 +89,10 @@ class Experiment:
         if eeg:
             eeg.stop()
 
+    
     def show_instructions(instruction_text):
     
-        instruction_text = instruction_text % duration
+        self.instruction_text = self.instruction_text % duration
 
         # graphics
         mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)

--- a/eegnb/experiments/Experiment_readme.txt
+++ b/eegnb/experiments/Experiment_readme.txt
@@ -1,0 +1,13 @@
+
+
+Looking for a general implementation structure where base class implements and passes the following functions, 
+
+def load_stimulus() -> stim (some form of dd array)
+
+def present_stimulus() -> given trial details does specific thing for experiment 
+
+** Slight issue is that a lot of parameters will have to be passed which is not the best in practice
+
+Stuff that can be overwritten in general ...
+instruction_text
+parameter/trial

--- a/eegnb/experiments/Experment.py
+++ b/eegnb/experiments/Experment.py
@@ -1,0 +1,79 @@
+
+
+
+class Experiment:
+
+    def __init_():
+
+
+    def present(duration=120, eeg: EEG=None, save_fn=None, n_trials=2010, exp_name=""):
+        """ Do the present operation for a bunch of experiments """
+      
+        # Setup Trial list -> Common in most
+        parameter = np.random.binomial(1, 0.5, n_trials)
+        trials = DataFrame(dict(parameter=parameter, timestamp=np.zeros(n_trials)))
+
+        # Setup Graphics 
+        mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True) 
+        """ Does specific thing within Experiment Type to load stimulus data """
+
+        # Show Instruction Screen
+        show_instructions(duration=duration)
+
+        # Start EEG Stream, wait for signal to settle, and then pull timestamp for start point
+        if eeg:
+        if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
+            random_id = random.randint(1000,10000)
+            save_fn = generate_save_fn(eeg.device_name, "visual_n170", random_id, random_id, "unnamed")
+            print(
+                f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
+            )
+        eeg.start(save_fn, duration=record_duration + 5)
+
+        start = time()
+        
+        # Iterate through the events
+        for ii, trial in trials.iterrows():
+          
+            # Intertrial interval
+            core.wait(iti + np.random.rand() * jitter)
+
+            # Some form of presenting the stimulus - sometimes order changed in lower files like ssvep
+
+            # Push sample
+            if eeg:
+                timestamp = time()
+                if eeg.backend == "muselsl":
+                    marker = [markernames[label]]
+                else:
+                    marker = markernames[label]
+                eeg.push_sample(marker=marker, timestamp=timestamp)
+
+            # Offset
+            mywin.flip()
+            if len(event.getKeys()) > 0 or (time() - start) > record_duration:
+                break
+            event.clearEvents()
+
+
+        # Close the EEG stream 
+        if eeg:
+            eeg.stop()
+
+    def show_instructions(instruction_text):
+    
+        instruction_text = instruction_text % duration
+
+        # graphics
+        mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
+
+        mywin.mouseVisible = False
+
+        # Instructions
+        text = visual.TextStim(win=mywin, text=instruction_text, color=[-1, -1, -1])
+        text.draw()
+        mywin.flip()
+        event.waitKeys(keyList="space")
+
+        mywin.mouseVisible = True
+        mywin.close()

--- a/eegnb/experiments/Experment.py
+++ b/eegnb/experiments/Experment.py
@@ -1,5 +1,20 @@
 
 
+"""
+Right now the quesitons are simple 
+
+1. Do we want to have as much code as possible in the master class, somewhat like a main function that works with generic types
+being passed in? EG. Experiment class has all the code, specific functions, variables, events and stimuli are passed in that are 
+called according to the stage of the cycle
+
+2. Do we want to just have a common set of shared data members in the form of a data class as per Issue 76?
+
+3. Do we want to split the main piece of code into a lot of functions like settng up trials, graphics, etc?
+
+4. How different are the next experiments that are going to be incorporated be? Will they be able to stick to such a protocol?
+
+"""
+
 
 class Experiment:
 

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -18,7 +18,38 @@ from eegnb import generate_save_fn
 from eegnb.devices.eeg import EEG
 from eegnb.stimuli import FACE_HOUSE
 
+
+
+
 __title__ = "Visual N170"
+
+
+def load_stimulus():
+    def load_image(fn):
+        return visual.ImageStim(win=mywin, image=fn)
+    faces = list(map(load_image, glob(os.path.join(FACE_HOUSE, "faces", "*_3.jpg"))))
+    houses = list(map(load_image, glob(os.path.join(FACE_HOUSE, "houses", "*.3.jpg"))))
+    stim = [houses, faces]
+    return stim
+
+instruction_text = """
+    Welcome to the N170 experiment! 
+ 
+    Stay still, focus on the centre of the screen, and try not to blink. 
+
+    This block will run for %s seconds.
+
+    Press spacebar to continue. 
+    
+    """
+
+
+if __name__ == "__main__":
+     
+    test = Experiment()
+    test.instruction_text = instruction_text
+    test.load_stimulus = load_stimulus
+    test.run()
 
 
 def present(duration=120, eeg: EEG=None, save_fn=None,
@@ -39,9 +70,6 @@ def present(duration=120, eeg: EEG=None, save_fn=None,
     # Setup graphics
     mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
 
-    faces = list(map(load_image, glob(os.path.join(FACE_HOUSE, "faces", "*_3.jpg"))))
-    houses = list(map(load_image, glob(os.path.join(FACE_HOUSE, "houses", "*.3.jpg"))))
-    stim = [houses, faces]
 
     # Show the instructions screen
     show_instructions(duration)
@@ -63,6 +91,7 @@ def present(duration=120, eeg: EEG=None, save_fn=None,
         # Inter trial interval
         core.wait(iti + np.random.rand() * jitter)
 
+        
         # Select and display image
         label = trials["image_type"].iloc[ii]
         image = choice(faces if label == 1 else houses)
@@ -97,7 +126,7 @@ def present(duration=120, eeg: EEG=None, save_fn=None,
 def show_instructions(duration):
 
     instruction_text = """
-    Welcome to the N170 experiment! 
+    Welcome to the {} experiment! 
  
     Stay still, focus on the centre of the screen, and try not to blink. 
 
@@ -105,7 +134,8 @@ def show_instructions(duration):
 
     Press spacebar to continue. 
     
-    """
+    """.format(self.experiment_id)
+
     instruction_text = instruction_text % duration
 
     # graphics

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -17,137 +17,40 @@ from psychopy import visual, core, event
 from eegnb import generate_save_fn
 from eegnb.devices.eeg import EEG
 from eegnb.stimuli import FACE_HOUSE
-
-
-
-
-__title__ = "Visual N170"
+from Experiment import Experiment
 
 
 def load_stimulus():
-    def load_image(fn):
-        return visual.ImageStim(win=mywin, image=fn)
+    
+    load_image = lambda fn: visual.ImageStim(win=mywin, image=fn)
+    
     faces = list(map(load_image, glob(os.path.join(FACE_HOUSE, "faces", "*_3.jpg"))))
     houses = list(map(load_image, glob(os.path.join(FACE_HOUSE, "houses", "*.3.jpg"))))
-    stim = [houses, faces]
-    return stim
 
-instruction_text = """
-    Welcome to the N170 experiment! 
- 
-    Stay still, focus on the centre of the screen, and try not to blink. 
-
-    This block will run for %s seconds.
-
-    Press spacebar to continue. 
+    return [houses, faces]
     
-    """
+def present_stimulus(trials, ii, eeg, markernames):
+   
+    label = trials["image_type"].iloc[ii]
+    image = choice(faces if label == 1 else houses)
+    image.draw()
 
+    # Push sample
+    if eeg:
+        timestamp = time()
+        if eeg.backend == "muselsl":
+            marker = [markernames[label]]
+        else:
+            marker = markernames[label]
+        eeg.push_sample(marker=marker, timestamp=timestamp)
+   
 
 if __name__ == "__main__":
      
-    test = Experiment()
+    test = Experiment("Visual N170")
     test.instruction_text = instruction_text
     test.load_stimulus = load_stimulus
-    test.run()
+    test.present_stimulus = present_stimulus
+    test.setup()
+    test.present()
 
-
-def present(duration=120, eeg: EEG=None, save_fn=None,
-            n_trials = 2010, iti = 0.4, soa = 0.3, jitter = 0.2):
-    
-    record_duration = np.float32(duration)
-    markernames = [1, 2]
-
-    # Setup trial list
-    image_type = np.random.binomial(1, 0.5, n_trials)
-    trials = DataFrame(dict(image_type=image_type, timestamp=np.zeros(n_trials)))
-
-    def load_image(fn):
-        return visual.ImageStim(win=mywin, image=fn)
-
-    # start the EEG stream, will delay 5 seconds to let signal settle
-
-    # Setup graphics
-    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
-
-
-    # Show the instructions screen
-    show_instructions(duration)
-
-    if eeg:
-        if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
-            random_id = random.randint(1000,10000)
-            save_fn = generate_save_fn(eeg.device_name, "visual_n170", random_id, random_id, "unnamed")
-            print(
-                f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
-            )
-        eeg.start(save_fn, duration=record_duration + 5)
-
-    # Start EEG Stream, wait for signal to settle, and then pull timestamp for start point
-    start = time()
-
-    # Iterate through the events
-    for ii, trial in trials.iterrows():
-        # Inter trial interval
-        core.wait(iti + np.random.rand() * jitter)
-
-        
-        # Select and display image
-        label = trials["image_type"].iloc[ii]
-        image = choice(faces if label == 1 else houses)
-        image.draw()
-
-        # Push sample
-        if eeg:
-            timestamp = time()
-            if eeg.backend == "muselsl":
-                marker = [markernames[label]]
-            else:
-                marker = markernames[label]
-            eeg.push_sample(marker=marker, timestamp=timestamp)
-
-        mywin.flip()
-
-        # offset
-        core.wait(soa)
-        mywin.flip()
-        if len(event.getKeys()) > 0 or (time() - start) > record_duration:
-            break
-
-        event.clearEvents()
-
-    # Cleanup
-    if eeg:
-        eeg.stop()
-
-    mywin.close()
-
-
-def show_instructions(duration):
-
-    instruction_text = """
-    Welcome to the {} experiment! 
- 
-    Stay still, focus on the centre of the screen, and try not to blink. 
-
-    This block will run for %s seconds.
-
-    Press spacebar to continue. 
-    
-    """.format(self.experiment_id)
-
-    instruction_text = instruction_text % duration
-
-    # graphics
-    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
-
-    mywin.mouseVisible = False
-
-    # Instructions
-    text = visual.TextStim(win=mywin, text=instruction_text, color=[-1, -1, -1])
-    text.draw()
-    mywin.flip()
-    event.waitKeys(keyList="space")
-
-    mywin.mouseVisible = True
-    mywin.close()

--- a/eegnb/experiments/visual_p300/p300.py
+++ b/eegnb/experiments/visual_p300/p300.py
@@ -10,126 +10,39 @@ from psychopy import visual, core, event
 from eegnb import generate_save_fn
 from eegnb.stimuli import CAT_DOG
 
-__title__ = "Visual P300"
 
-instruction_text = """
-    Welcome to the P300 experiment! 
- 
-    Stay still, focus on the centre of the screen, and try not to blink. 
-
-    This block will run for %s seconds.
-
-    Press spacebar to continue. 
-    
-    """
-    
 def load_stimulus():
-    pass
+    load_image = lambda fn: visual.ImageStim(win=mywin, image=fn)
+    # Setup graphics
+    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
+    targets = list(map(load_image, glob(os.path.join(CAT_DOG, "target-*.jpg"))))
+    nontargets = list(map(load_image, glob(os.path.join(CAT_DOG, "nontarget-*.jpg"))))
+    
+    return [nontargets, targets]
 
-def present_stimulus():
-    pass
+def present_stimulus(trials, ii, eeg, markernames):
 
+    label = trials["image_type"].iloc[ii]
+    image = choice(targets if label == 1 else nontargets)
+    image.draw()
+
+    # Push sample
+    if eeg:
+        timestamp = time()
+        if eeg.backend == "muselsl":
+            marker = [markernames[label]]
+        else:
+            marker = markernames[label]
+        eeg.push_sample(marker=marker, timestamp=timestamp)
 
 if __name__ == "__main__":
 
-    test = Experiment()
-
-
-
-def present(duration=120, eeg=None, save_fn=None):
-    n_trials = 2010
-    iti = 0.4
-    soa = 0.3
-    jitter = 0.2
-    record_duration = np.float32(duration)
-    markernames = [1, 2]
-
-    # Setup trial list
-    image_type = np.random.binomial(1, 0.5, n_trials)
-    trials = DataFrame(dict(image_type=image_type, timestamp=np.zeros(n_trials)))
-
-    def load_image(fn):
-        return visual.ImageStim(win=mywin, image=fn)
-
-    # Setup graphics
-    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
-
-    targets = list(map(load_image, glob(os.path.join(CAT_DOG, "target-*.jpg"))))
-    nontargets = list(map(load_image, glob(os.path.join(CAT_DOG, "nontarget-*.jpg"))))
-    stim = [nontargets, targets]
-
-    # Show instructions
-    show_instructions(duration=duration)
-
-    # start the EEG stream, will delay 5 seconds to let signal settle
-    if eeg:
-        if save_fn is None:  # If no save_fn passed, generate a new unnamed save file
-            save_fn = generate_save_fn(eeg.device_name, "visual_p300", "unnamed")
-            print(
-                f"No path for a save file was passed to the experiment. Saving data to {save_fn}"
-            )
-        eeg.start(save_fn, duration=record_duration)
-
-    # Iterate through the events
-    start = time()
-    for ii, trial in trials.iterrows():
-        # Inter trial interval
-        core.wait(iti + np.random.rand() * jitter)
-
-        # Select and display image
-        label = trials["image_type"].iloc[ii]
-        image = choice(targets if label == 1 else nontargets)
-        image.draw()
-
-        # Push sample
-        if eeg:
-            timestamp = time()
-            if eeg.backend == "muselsl":
-                marker = [markernames[label]]
-            else:
-                marker = markernames[label]
-            eeg.push_sample(marker=marker, timestamp=timestamp)
-
-        mywin.flip()
-
-        # offset
-        core.wait(soa)
-        mywin.flip()
-        if len(event.getKeys()) > 0 or (time() - start) > record_duration:
-            break
-
-        event.clearEvents()
-
-    # Cleanup
-    if eeg:
-        eeg.stop()
-    mywin.close()
-
-
-def show_instructions(duration):
-
-    instruction_text = """
-    Welcome to the P300 experiment! 
- 
-    Stay still, focus on the centre of the screen, and try not to blink. 
-
-    This block will run for %s seconds.
-
-    Press spacebar to continue. 
+    test = Experiment("Visual P300")
+    test.instruction_text = instruction_text
+    test.load_stimulus = load_stimulus
+    test.present_stimulus = present_stimulus
+    test.setup()
+    test.present()
     
-    """
-    instruction_text = instruction_text % duration
 
-    # graphics
-    mywin = visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True)
 
-    mywin.mouseVisible = False
-
-    # Instructions
-    text = visual.TextStim(win=mywin, text=instruction_text, color=[-1, -1, -1])
-    text.draw()
-    mywin.flip()
-    event.waitKeys(keyList="space")
-
-    mywin.mouseVisible = True
-    mywin.close()

--- a/eegnb/experiments/visual_p300/p300.py
+++ b/eegnb/experiments/visual_p300/p300.py
@@ -12,6 +12,29 @@ from eegnb.stimuli import CAT_DOG
 
 __title__ = "Visual P300"
 
+instruction_text = """
+    Welcome to the P300 experiment! 
+ 
+    Stay still, focus on the centre of the screen, and try not to blink. 
+
+    This block will run for %s seconds.
+
+    Press spacebar to continue. 
+    
+    """
+    
+def load_stimulus():
+    pass
+
+def present_stimulus():
+    pass
+
+
+if __name__ == "__main__":
+
+    test = Experiment()
+
+
 
 def present(duration=120, eeg=None, save_fn=None):
     n_trials = 2010


### PR DESCRIPTION

Defined General Experiment Class type that does all of the operations besides loading and presenting the stimulus which is overriden by the derived classes. As of now it incorporates the Visual N170 and Visual P300 experiments - and working towards incorporating Visual SSVEP. 

Some things worth thinking about, for the present_stimulus function, a lot of parameters are being passed which is annoying me, so I want to know if it would be smarter to pass the Experiment as an object instead (although I know in general that's bad practice). It also gives us a lot of flexibility for the future complex experiements. 

Additionally, since all the main functions are delegated to lower classes, this mechanism should allow a lot of complexity and specificity and generally think this should work (and it looks cool too!). 

Has not been tested besides compiling, so that needs to be done once whilst I work towards incorporating the rest of the experiments.