### PR TITLE
fixed requirements.txt so 'pip install -e .' would work on windows.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pywinhook @ https://github.com/ActivityWatch/wheels/raw/master/pywinhook/pyWinho
 
 # pyglet downgrade to prevent threadmode warning on windows
 # See issue: https://github.com/psychopy/psychopy/issues/2876
-pyglet==1.4.10 ; platform_system == "Windows"
+pyglet==1.4.11 ; platform_system == "Windows"
 
 # Test requirements
 mypy


### PR DESCRIPTION
I had to upgrade this due to psychopy depending on it, this error was being thrown when doing a `pip install -e .`:
```
The conflict is caused by:
    eeg-notebooks 0.2 depends on pyglet==1.4.10; platform_system == "Windows"
    psychopy 2023.1.0 depends on pyglet==1.4.11
```