### PR TITLE
fixed docs build on macOS-latest 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 build:
-	pip install .
+	# Use pep517 to install pygatt==4.0.5(deprecated setuptools/egg installer) on macos
+	pip install --use-pep517 .
 
 test:
 	pytest


### PR DESCRIPTION
I had to add the argument --use-pep517 to pip install due to the pygatt dependency using a deprecatred setuptools/egg installer.