### PR TITLE
fix: update readme with full img path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ EEG-ExPy
 .. |badge_binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/NeuroTechX/eeg-expy/master
 
-.. image:: doc/img/EEG-ExPy_Logo.png
+.. image:: https://github.com/NeuroTechX/EEG-ExPy/blob/master/doc/img/EEG-ExPy_Logo.png
    :align: center
 
 EEG-ExPy is a collection of classic EEG experiments, implemented in Python. The experimental protocols and analyses are quite generic, but are primarily taylored for low-budget / consumer EEG hardware such as the InteraXon MUSE and OpenBCI Cyton. The goal is to make cognitive neuroscience and neurotechnology more accessible, affordable, and scalable. 
@@ -87,7 +87,7 @@ The best place for general discussion on eeg-expy functionality is the `issues p
 
 
 
-.. image:: ./doc/img/eeg-notebooks_democratizing_the_cogneuro_experiment.png
+.. image:: https://github.com/NeuroTechX/EEG-ExPy/blob/master/doc/img/eeg-notebooks_democratizing_the_cogneuro_experiment.png
    :align: center
    :scale: 50
    


### PR DESCRIPTION
re-added the paths because relative path mapping didn't display the image in the sphinx generated docs on https://neurotechx.github.io/EEG-ExPy/