### PR TITLE
Changes needed to get EEG-ExPy building and running on Apple Silicon chips

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,7 @@ jobs:
         publish_dir: doc/_build/html
     - name: Deploy Dev Docs
       uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/develop' && github.repository == 'NeuroTechX/EEG-ExPy'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: doc/_build/html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,26 @@ jobs:
       if: "startsWith(runner.os, 'Linux')"
       run: |
         make install-deps-wxpython
+    - name: Install conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        environment-file: environment.yml
+        auto-activate-base: true
+        python-version: 3.8
+        activate-environment: EEG-ExPy
+        channels: conda-forge
+        miniconda-version: "latest"
+    - name: Install dependencies via conda
+      shell: bash -el {0}
+      run: |
+        conda info
+        conda activate EEG-ExPy
     - name: Install dependencies
+      shell: bash -el {0}
       run: |
         make build
     - name: Run eegnb install test
-      shell: bash
+      shell: bash -el {0}
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
           Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> xvfb.log &
@@ -65,7 +80,7 @@ jobs:
         eegnb --help
         eegnb runexp --help
     - name: Run examples with coverage
-      shell: bash
+      shell: bash -el {0}
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
           Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> xvfb.log &

--- a/eegnb/analysis/analysis_utils.py
+++ b/eegnb/analysis/analysis_utils.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from glob import glob
 from typing import Union, List
 from time import sleep, time
-import keyboard
 import os
 
 import pandas as pd

--- a/eegnb/analysis/streaming_utils.py
+++ b/eegnb/analysis/streaming_utils.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from glob import glob
 from typing import Union, List
 from time import sleep, time
-import keyboard
+from pynput import keyboard
 import os
 
 import pandas as pd
@@ -192,12 +192,20 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=None, th
             print(f"\n\nLooks like you still have {len(bad_channels)} bad channels after {loop_index+1} tries\n")
 
             prompt_time = time()
-            print(f"Starting next cycle in 5 seconds, press C and enter to cancel")    
-            while time() < prompt_time + 5:  
-                if keyboard.is_pressed('c'): 
+            print(f"Starting next cycle in 5 seconds, press C and enter to cancel")
+            c_key_pressed = False
+
+            def update_key_press(key):
+                if key.char == 'c':
+                    globals().update(c_key_pressed=True)
+            listener = keyboard.Listener(on_press=update_key_press)
+            listener.start()
+            while time() < prompt_time + 5:
+                if c_key_pressed:
                     print("\nStopping signal quality checks!")
                     flag = True
-                    break  
+                    break
+            listener.stop()
         if flag: 
             break  
 

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from glob import glob
 from typing import Union, List
 from time import sleep, time
-import keyboard
 import os
 
 import pandas as pd

--- a/eegnb/experiments/auditory_oddball/aob.py
+++ b/eegnb/experiments/auditory_oddball/aob.py
@@ -1,5 +1,8 @@
 import numpy as np
 from pandas import DataFrame
+from psychopy import prefs
+# PTB does not yet support macOS Apple Silicon, need to fall back to sounddevice.
+prefs.hardware['audioLib'] = ['sounddevice']
 from psychopy import visual, core, event, sound
 
 from time import time

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+channels:
+    - conda-forge
+dependencies:
+    - python=3.8
+    - pytables # install pytables for macOS arm64, so do not need to build from source.
+    - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,9 @@ pyserial>=3.5
 h5py>=3.1.0
 pytest-shutil
 pyo>=1.0.3; platform_system == "Linux"
-keyboard==0.13.5
+#pynput requires pyobjc, psychopy requires a version less than 8, setting pyobjc to
+# a specific version prevents an endless dependency resolution loop.
+pyobjc==7.3; sys_platform == 'darwin'
 airium>=0.1.0
 attrdict>=2.0.1
 attrdict3
@@ -24,14 +26,20 @@ attrdict3
 ## ~~ Streaming Requirements ~~ 
 
 muselsl>=2.0.2
-pylsl==1.10.5  # due to https://github.com/NeuroTechX/eeg-notebooks/issues/187
+# Upgrade from 1.10.5 to 1.16.2 so the arm64 lib is available to macOS Apple Silicon for preventing error:
+# pylsl/liblsl64.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
+pylsl==1.16.2
 brainflow>=4.8.2
 pysocks>=1.7.1
 pyserial>=3.5
 h5py>=3.1.0
 pytest-shutil
 pyo>=1.0.3; platform_system == "Linux"
-keyboard==0.13.5
+#pynput requires pyobjc, psychopy requires a version less than 8, setting pyobjc to
+# a specific version prevents an endless dependency resolution loop.
+pyobjc==7.3; sys_platform == 'darwin'
+#Removed keyboard dependency due segmentation fault on Apple Silicon: https://github.com/boppreh/keyboard/issues/507
+pynput
 airium>=0.1.0
 attrdict>=2.0.1
 attrdict3
@@ -40,7 +48,13 @@ click
 
 ## ~~ Stimpres Requirements ~~ 
 
-psychopy==2023.1.0
+#pynput requires pyobjc, psychopy requires a version less than 8, setting pyobjc to
+# a specific version prevents an endless dependency resolution loop.
+pyobjc==7.3; sys_platform == 'darwin'
+#upgrade psychopy to use newer wxpython dependency which is prebuilt for m1 support.
+psychopy==2023.2.2
+# PTB does not yet support macOS Apple Silicon, need to fallback to sounddevice.
+psychopy-sounddevice
 psychtoolbox
 scikit-learn>=0.23.2
 pandas>=1.1.4
@@ -52,7 +66,6 @@ pyserial>=3.5
 h5py>=3.1.0
 pytest-shutil
 pyo>=1.0.3; platform_system == "Linux"
-keyboard==0.13.5
 airium>=0.1.0
 attrdict>=2.0.1
 attrdict3


### PR DESCRIPTION
Biggest changes needed were using conda to install some dependencies on the MacOS-latest github runner.  Conda is already part of the normal installation process so might be ok?
Unfortunately had to remove the keyboard module entirely since it is currently throwing a segmentation fault on Apple Silicon macOS, luckily it seems to have been only used in one place and I replaced it with the pynput module, still have not tested the replaced code yet though.