### PR TITLE
bugfix: pass down trial parameter to subclass.

### DIFF
--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -185,7 +185,7 @@ class BaseExperiment:
                 if rendering_trial < current_trial:
                     # Some form of presenting the stimulus - sometimes order changed in lower files like ssvep
                     # Stimulus presentation overwritten by specific experiment
-                    self.__draw(lambda: self.present_stimulus(current_trial, current_trial))
+                    self.__draw(lambda: self.present_stimulus(current_trial))
                     rendering_trial = current_trial
             else:
                 self.__draw(lambda: self.window.flip())

--- a/eegnb/experiments/__init__.py
+++ b/eegnb/experiments/__init__.py
@@ -1,4 +1,10 @@
 from .visual_n170.n170 import VisualN170
 from .visual_p300.p300 import VisualP300
 from .visual_ssvep.ssvep import VisualSSVEP
-from .auditory_oddball.aob import AuditoryOddball
+
+# PTB does not yet support macOS Apple Silicon,
+# this experiment needs to run as i386 if on macOS.
+import sys
+import platform
+if sys.platform != 'darwin' or platform.processor() != 'arm':
+    from .auditory_oddball.aob import AuditoryOddball

--- a/eegnb/experiments/auditory_oddball/aob.py
+++ b/eegnb/experiments/auditory_oddball/aob.py
@@ -1,8 +1,12 @@
 import numpy as np
 from pandas import DataFrame
 from psychopy import prefs
+
 # PTB does not yet support macOS Apple Silicon, need to fall back to sounddevice.
-prefs.hardware['audioLib'] = ['sounddevice']
+import sys
+if sys.platform == 'darwin':
+    prefs.hardware['audioLib'] = ['sounddevice']
+
 from psychopy import visual, core, event, sound
 
 from time import time
@@ -72,11 +76,11 @@ class AuditoryOddball(Experiment.BaseExperiment):
 
         return 
     
-    def present_stimulus(self, idx : int, trial):
+    def present_stimulus(self, idx: int):
         """ Presents the Stimulus """
 
         # Select and play sound
-        ind = int(trial["sound_ind"])
+        ind = int(self.trials["sound_ind"].iloc[idx])
         self.auds[ind].stop()
         self.auds[ind].play()
 

--- a/eegnb/experiments/auditory_oddball/aob.py
+++ b/eegnb/experiments/auditory_oddball/aob.py
@@ -2,11 +2,6 @@ import numpy as np
 from pandas import DataFrame
 from psychopy import prefs
 
-# PTB does not yet support macOS Apple Silicon, need to fall back to sounddevice.
-import sys
-if sys.platform == 'darwin':
-    prefs.hardware['audioLib'] = ['sounddevice']
-
 from psychopy import visual, core, event, sound
 
 from time import time

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -41,7 +41,7 @@ class VisualN170(Experiment.BaseExperiment):
         # Return the list of images as a stimulus object
         return [self.houses, self.faces]
         
-    def present_stimulus(self, idx : int, trial):
+    def present_stimulus(self, idx: int):
         
         # Get the label of the trial
         label = self.trials["parameter"].iloc[idx]

--- a/eegnb/experiments/visual_p300/p300.py
+++ b/eegnb/experiments/visual_p300/p300.py
@@ -35,7 +35,7 @@ class VisualP300(Experiment.BaseExperiment):
         
         return [self.nontargets, self.targets]
 
-    def present_stimulus(self, idx:int, trial):
+    def present_stimulus(self, idx: int):
 
         label = self.trials["parameter"].iloc[idx]
         image = choice(self.targets if label == 1 else self.nontargets)

--- a/eegnb/experiments/visual_ssvep/ssvep.py
+++ b/eegnb/experiments/visual_ssvep/ssvep.py
@@ -91,8 +91,8 @@ class VisualSSVEP(Experiment.BaseExperiment):
             init_flicker_stim(frame_rate, 3, self.soa),
         ]
 
-    def present_stimulus(self, idx, trial):
-        
+    def present_stimulus(self, idx: int):
+
         # Select stimulus frequency
         ind = self.trials["parameter"].iloc[idx]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,8 +53,6 @@ click
 pyobjc==7.3; sys_platform == 'darwin'
 #upgrade psychopy to use newer wxpython dependency which is prebuilt for m1 support.
 psychopy==2023.2.2
-# PTB does not yet support macOS Apple Silicon, need to fallback to sounddevice.
-psychopy-sounddevice
 psychtoolbox
 scikit-learn>=0.23.2
 pandas>=1.1.4


### PR DESCRIPTION
bugfix: pass down trial parameter to subclass as was previously done before VR code modified rendering logic.

Also fixed baseclass 'present_stimulus' method signature to match arguments as expected for subclass to implement.

This was something which I accidentally had modified the behaviour of - I had trouble understanding what the 'trial' parameter was used for in the experiments.
It seems like none of the example experiments are using the parameter.