### PR TITLE
(Merge to master) fixes to allow for setting a custom data_dir outside of ~/.eegnb/

### DIFF
--- a/eegnb/__init__.py
+++ b/eegnb/__init__.py
@@ -30,7 +30,7 @@ def _get_recording_dir(
     data_dir=DATA_DIR,
 ) -> Path:
     """A subroutine of get_recording_dir that accepts subject and session as strings"""
-    # folder structure is /DATA_DIR/experiment/site/subject/session/*.csv
+    # folder structure is /DATA_DIR/experiment/board_name/site/subject/session/*.csv
     recording_dir = (
         Path(data_dir) / experiment / site / board_name / subject_str / session_str
     )
@@ -51,7 +51,7 @@ def generate_save_fn(
 ) -> Path:
     """Generates a file name with the proper trial number for the current subject/experiment combo"""
     recording_dir = get_recording_dir(
-        board_name, experiment, subject_id, session_nb, data_dir=DATA_DIR
+        board_name, experiment, subject_id, session_nb, data_dir=data_dir
     )
 
     # generate filename based on recording date-and-timestamp and then append to recording_dir

--- a/eegnb/analysis/analysis_utils.py
+++ b/eegnb/analysis/analysis_utils.py
@@ -179,7 +179,7 @@ def load_data(
     subject_str = "*" if subject == "all" else f"subject{subject_int:04}"
     session_str = "*" if session == "all" else f"session{session_int:03}"
 
-    recdir = _get_recording_dir(device_name, experiment, subject_str, session_str, site)#, data_dir)
+    recdir = _get_recording_dir(device_name, experiment, subject_str, session_str, site, data_dir)
     data_path = os.path.join(data_dir, recdir, "*.csv")
 
     fnames = glob(str(data_path))

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -179,7 +179,7 @@ def load_data(
     subject_str = "*" if subject == "all" else f"subject{subject_int:04}"
     session_str = "*" if session == "all" else f"session{session_int:03}"
 
-    recdir = _get_recording_dir(device_name, experiment, subject_str, session_str, site)#, data_dir)
+    recdir = _get_recording_dir(device_name, experiment, subject_str, session_str, site, data_dir)
     data_path = os.path.join(data_dir, recdir, "*.csv")
 
     fnames = glob(str(data_path))


### PR DESCRIPTION
As previously discussed in our meeting, I could not save my recordings outside of ~/.eegnb/
This fixes the issue.
Here is an example of how I set my recordings/data directory using an environment variable.
I modify this environment variable depending on the computer I am running the recording or analysis on, I'm saving my data to a private experiments repository which has a different local directory on each computer.
### recording
```# generate save path
data_dir = path.join(path.expanduser("~/"), getenv('DATA_DIR'), "data")
save_fn = generate_save_fn(eeg_device.device_name, experiment_name, subject_id, session_nb, data_dir)
```
### loading
```

data_dir = path.join(path.expanduser("~/"), getenv('DATA_DIR'), "data")
raw = load_data(subject,session,
                experiment='visual_n170', site='local', device_name='synthetic',
                data_dir = data_dir)
```