### PR TITLE
Make full screen optional

### DIFF
--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -28,7 +28,7 @@ from eegnb import generate_save_fn
 class BaseExperiment:
 
     def __init__(self, exp_name, duration, eeg, save_fn, n_trials: int, iti: float, soa: float, jitter: float,
-                 use_vr=False):
+                 use_vr=False, use_fullscr = True):
         """ Initializer for the Base Experiment Class
 
         Args:
@@ -50,6 +50,8 @@ class BaseExperiment:
         self.soa = soa
         self.jitter = jitter
         self.use_vr = use_vr
+        self.use_fullscr = use_fullscr
+        self.window_size = [1600,800] 
 
     @abstractmethod
     def load_stimulus(self):
@@ -85,7 +87,7 @@ class BaseExperiment:
         # Setting up Graphics 
         self.window = (
             visual.Rift(monoscopic=True, headLocked=True) if self.use_vr
-            else visual.Window([1600, 900], monitor="testMonitor", units="deg", fullscr=True))
+            else visual.Window(self.window_size, monitor="testMonitor", units="deg", fullscr=self.use_fullscr))
         
         # Loading the stimulus from the specific experiment, throws an error if not overwritten in the specific experiment
         self.stim = self.load_stimulus()


### PR DESCRIPTION

Following idea from @pellet - this is a tiny PR to make the use of full screen optional. 

This is particularly useful for debugging, because it allows to both see and switch to a terminal while the psychopy window is up, and allows to retain control via the terminal upon a crash, for e.g. to view the stack trace or enter a debugger. 

This is done by providing a `use_fullscr` `Bool` argument in the experiment init, and setting it to a modifiable attribute of the `Experiment` object. 

A modifiable attribute is also added for `window_size`, although this is not added as an input argument upon init. 

I think it would probably be a good idea to move some other parameters such as the monitor type into modifiable object attributes in the future also. 

Example usage: 

```python
from eegnb.experiments.visual_n170.n170 import VisualN170
expt = VisualN170(duration=10, use_fullscr = False)
exp.window_size = [1200,500]
exp.run()
```
