### PR TITLE
encapsulate trial params

### DIFF
--- a/eegnb/experiments/utils/__init__.py
+++ b/eegnb/experiments/utils/__init__.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+@dataclass
+class TrialParams:
+    """
+    Encapsulates parameters for defining trials in EEG experiments.
+
+    This dataclass provides a structured way to define and manage trial-specific
+    parameters, particularly timing information, for EEG studies. It's designed
+    to be flexible enough for use in various experimental paradigms, including
+    but not limited to event-related designs.
+
+    Attributes:
+        iti (float): Inter-Trial Interval, in seconds. The base time between
+                     the end of one trial and the beginning of the next.
+        jitter (float): Maximum random time, in seconds, added to the ITI.
+                        Used to prevent anticipatory responses and increase
+                        design efficiency in event-related paradigms.
+        soa (float): Stimulus On Arrival, in seconds. The duration the
+                     stimulus is shown for until the trial ends.
+        n_trials (int): The total number of trials in the experiment.
+
+    Example:
+        # Create parameters 1s ITI, up to 0.2s jitter, and 0.5s SOA for 100 trials.
+        params = TrialParams(iti=1.0, jitter=0.2, soa=0.5, n_trials=100)
+    """
+
+    iti: float
+    jitter: float
+    soa: float
+    n_trials: int


### PR DESCRIPTION
This is an example of the idea I had to encapsulate the parameters being passed into the BaseExperiment class.
We could do something similar with options related to presenting the experiment window.
This change organizes the trial options so they will be grouped together separate from the other parameters.
It will reduce the number of arguments being passed into the BaseExperiment init method.
Any ideas on how to organize the trial option dataclass will be appreciated - it seems the BaseExperiment class and accompanying trial options are suited for 'Event Related' experiments.  Some modifications may be needed to better support 'Block' and 'Continuous' experiments such as the resting state experiment @tmorshed had created.
The PR is not ready to merge, I haven't tested it yet - more here to start a conversation.