### PR TITLE
Resolve broken references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ EEG-ExPy
    :align: center
 
 
-EEG-ExPy is a collection of classic EEG experiments, implemented in Python. The experimental protocols and analyses are quite generic, but are primarily taylored for low-budget / consumer EEG hardware such as the InteraXon MUSE and OpenBCI Cyton. The goal is to make cognitive neuroscience and neurotechnology more accessible, affordable, and scalable. 
+EEG-ExPy is a collection of classic EEG experiments, implemented in Python. The experimental protocols and analyses are quite generic, but are primarily tailored for low-budget / consumer EEG hardware such as the InteraXon MUSE and OpenBCI Cyton. The goal is to make cognitive neuroscience and neurotechnology more accessible, affordable, and scalable.
 
 - **For an intro talk on the ***EEG-ExPy*** (formerly ***eeg-notebooks***) project see:** `JG's Brainhack Ontario presentation <https://www.crowdcast.io/e/brainhack-ontario/7>`_.  
 - **For documentation see:** `documentation site <https://neurotechx.github.io/EEG-ExPy/index.html>`_.
@@ -65,11 +65,11 @@ Check the `changelog <https://neurotechx.github.io/EEG-ExPy/changelog.html>`_ fo
 Acknowledgments
 ----------------
 
-EEG-Notebooks was created by the `NeurotechX <https://neurotechx.com/>`_ hacker/developer/neuroscience community. The ininitial idea and majority of the groundwork was due to Alexandre Barachant - including the `muse-lsl <https://github.com/alexandrebarachant/muse-lsl/>`_ library, which is core dependency. Lead developer on the project is now `John Griffiths <www.grifflab.com>`_ . 
+EEG-Notebooks was created by the `NeurotechX <https://neurotechx.com/>`_ hacker/developer/neuroscience community. The ininitial idea and majority of the groundwork was due to Alexandre Barachant - including the `muse-lsl <https://github.com/alexandrebarachant/muse-lsl/>`_ library, which is core dependency. Lead developer on the project is now `John Griffiths <https://www.grifflab.com>`_ .
 
 Key contributors include: Alexandre Barachant, Hubert Banville, Dano Morrison, Ben Shapiro, John Griffiths, Amanda Easson, Kyle Mathewson, Jadin Tredup, Erik Bjäreholt. 
 
-Thanks also to Andrey Parfenov for the excellent `brainflow <https://github.com/brainflow-dev/brainflow/>`_ library, which has allowed us to dramatically expand the range of supporte devices; as well as the developers of `PsychoPy <https://github.com/psychopy/psychopy/>`_ and `MNE <https://github.com/mne-tools/mne-python/>`_, which together make up the central scaffolding of eeg-expy. 
+Thanks also to Andrey Parfenov for the excellent `brainflow <https://github.com/brainflow-dev/brainflow/>`_ library, which has allowed us to dramatically expand the range of supported devices; as well as the developers of `PsychoPy <https://github.com/psychopy/psychopy/>`_ and `MNE <https://github.com/mne-tools/mne-python/>`_, which together make up the central scaffolding of eeg-expy.
 
 
 Contribute

--- a/doc/getting_started/running_experiments.md
+++ b/doc/getting_started/running_experiments.md
@@ -3,7 +3,7 @@ After you have installed the library there are two methods for collecting data. 
 
 ## Command Line Interface
 To activate the command line tool, open a command/terminal prompt and enter `eegnb runexp` followed by the appropriate flags for your device, desired experiment, and more. The possible flags are
-* *-ed ; --eegdevice*: The device being used to record data. Each device has a specific string to be passed which can be seen on the [Initiating an EEG Stream](https://neurotechx.github.io/eeg-notebooks/getting_started/streaming.html) under the `EEG.device` parameter for the respective device.
+* *-ed ; --eegdevice*: The device being used to record data. Each device has a specific string to be passed which can be seen on the [Initiating an EEG Stream](https://neurotechx.github.io/EEG-ExPy/getting_started/streaming.html) under the `EEG.device` parameter for the respective device.
 * *-ex ; --experiment*: The experiment to be run
 * *-ma ; --macaddr*: The MAC address of device to use (applicable devices e.g ganglion)
 * *-rd ; --recdur*: Duration of recording (in seconds).
@@ -78,7 +78,7 @@ Enter session #:
 ```
 The session number corresponds to each time you sit down to take multiple recordings. If you put your device on and run this script 5 consecutive times you would use the same session number every time. However, if you were to take a break then return for an additional 3 recordings, the last 3 would have a new session number. For more information about how this corresponds to saving data please see the documentation page on loading and saving data. 
 
-If you are using **OpenBCI on Windows/MacOS** you will be given an additional prompt to enter the name of the serial port the USB dongle is using. For instructions on how to use the OpenBCI GUI to find the serial port see [Initiating an EEG Stream](https://neurotechx.github.io/eeg-notebooks/getting_started/streaming.html).
+If you are using **OpenBCI on Windows/MacOS** you will be given an additional prompt to enter the name of the serial port the USB dongle is using. For instructions on how to use the OpenBCI GUI to find the serial port see [Initiating an EEG Stream](https://neurotechx.github.io/EEG-ExPy/getting_started/streaming.html).
 
 
 
@@ -193,7 +193,7 @@ experiment = VisualN170(duration=record_duration, eeg=eeg_device, save_fn=save_f
 7. Ensure the electrodes are touching the scalp ok and not being blocked by the headset strap.
 8. From inside the VR headset's 'quick settings' dashboard, select 'Quest Link' and connect to the Oculus server running on windows, via air link or link cable.
 9. Once the Oculus menu has finished loading on the VR headset, open the built-in Oculus desktop app by using the touch controllers or gamepad.
-10. Try opening an eeg device raw data viwer and verify that the electrodes are receiving a good signal without too much noise, eg 'OpenBCI GUI'.
+10. Try opening an eeg device raw data viewer and verify that the electrodes are receiving a good signal without too much noise, eg 'OpenBCI GUI'.
 11. Run the EEG-ExPy experiment from the command line or IDE, it should load and take control from the Oculus desktop app.
 12. Follow the experiment instructions, and press a key if necessary to begin the experiment and collect valid data.
 

--- a/doc/misc/ntcs_phase1_instructions.md
+++ b/doc/misc/ntcs_phase1_instructions.md
@@ -2,7 +2,7 @@
 
 Welcome to the **NeuroTech Challenge Series (NTCS)**, **Phase 1 (P1)** instructions page. 
 
-**NTCSP1** is an international citizen science research study, run by researchers at the University of Toronto and the [CAMH KCNI](www.krembilneuroinformatics.ca), in collaboration with [OpenBCI](https://openbci.com), [NeuroTechX](www.neurotechx.com), and the eeg-expy core developer team. 
+**NTCSP1** is an international citizen science research study, run by researchers at the University of Toronto and the [CAMH KCNI](http://www.krembilneuroinformatics.ca), in collaboration with [OpenBCI](https://openbci.com), [NeuroTechX](https://neurotechx.com), and the eeg-expy core developer team.
 
 If this is the first time you are learning about NTCS, check out the [NTCS website](https://neurotech-challenge.com/) for additional info about this and other upcoming challenges and opportunities. 
 
@@ -127,7 +127,7 @@ Installation instructions: [https://conda.io/projects/conda/en/latest/user-guide
 
 ### 4. Set up environment and install eeg-expy
 Follow the instructions on this page of the eeg-expy docs
-[https://neurotechx.github.io/eeg-expy/getting_started/installation.html](https://neurotechx.github.io/eeg-expy/getting_started/installation.html)
+[https://neurotechx.github.io/EEG-ExPy/getting_started/installation.html](https://neurotechx.github.io/EEG-ExPy/getting_started/installation.html)
 
 ```
 conda create -n "ntcs" python=3.7 git pip wxpython
@@ -146,7 +146,7 @@ pip install -e .
 First, some general notes:
 
 - We have some [general device and streaming notes](https://github.com/NeuroTechX/eeg-expy/blob/2ee42af999ed2d15626ea5865a2147791e1fbde7/doc/getting_started/streaming.md) 
-- Muse users should also check out the additional *muse device usage information* [here](https://github.com/NeuroTechX/eeg-noteexpy/blob/master/doc/misc/muse_info.md).
+- Muse users should also check out the additional *muse device usage information* [here](https://github.com/NeuroTechX/EEG-ExPy/blob/master/doc/misc/muse_info.md).
 
 
 #### 5.1 Windows+Muse device users 
@@ -163,7 +163,7 @@ Ideally the default option, Brainflow (with native bluetooth), will work well fo
 
 The `eeg-expy` codes for the 3 currently available muse models are `muse2016`, `muse2`, and `museS`.
 
-For each of these, there is the option to strean on either `muselsl` (via `BlueMuse`), `Brainflow` with *native* bluetooth, or `Brainflow` with *BLED dongle* bluetooth. For a muse 2 device, the codes for these three streaming options would be `muse2_bfn`, `muse2_bfb`, `muse2`.
+For each of these, there is the option to stream on either `muselsl` (via `BlueMuse`), `Brainflow` with *native* bluetooth, or `Brainflow` with *BLED dongle* bluetooth. For a muse 2 device, the codes for these three streaming options would be `muse2_bfn`, `muse2_bfb`, `muse2`.
 
 
 **How to check the brainflow is working ok with the muse**
@@ -317,5 +317,5 @@ This is a major gotcha. So much so we're listing it twice. If you are using Open
 
 ### Python is not 3.7
 
-- Python 3.8+ is not currently supported by `eeg-expy`. If you type `Python` and the prompt tells you it is not `Python 3.7`, and this was not something you indended, then something has gone wrong with your installation or environment setup. Go back and repeat the environment setup steps; if the issue persists, repeat the `miniconda` install steps. 
+- Python 3.8+ is not currently supported by `eeg-expy`. If you type `Python` and the prompt tells you it is not `Python 3.7`, and this was not something you intended, then something has gone wrong with your installation or environment setup. Go back and repeat the environment setup steps; if the issue persists, repeat the `miniconda` install steps.
 


### PR DESCRIPTION
# PR Summary
This small PR resolves broken references in the following pages:
- https://neurotechx.github.io/EEG-ExPy/misc/ntcs_phase1_instructions.html
- https://neurotechx.github.io/EEG-ExPy/getting_started/running_experiments.html
- https://neurotechx.github.io/EEG-ExPy/
It also fixes a few typos on those pages along the way.