### PR TITLE
Bunch of build fixes and type check fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master, develop, 'dev/*' ]
   pull_request:
     branches: [ master, develop ]
 
@@ -10,6 +10,9 @@ jobs:
   test:
     name: test (${{ matrix.os }}, py-${{ matrix.python_version }})
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:
@@ -28,46 +31,36 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python_version }}
-
-    # Not needed if pywinhook is installed from wheels
-    #- name: Install swig
-    #  if: "startsWith(runner.os, 'windows')"
-    #  run: |
-    #    (New-Object System.Net.WebClient).DownloadFile("http://prdownloads.sourceforge.net/swig/swigwin-4.0.1.zip","swigwin-4.0.1.zip");
-    #    Expand-Archive .\swigwin-4.0.1.zip .;
-    #    echo "$((Get-Item .).FullName)/swigwin-4.0.1" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
     - name: Install APT dependencies
       if: "startsWith(runner.os, 'Linux')"
       run: |
         make install-deps-apt
-    - name: Upgrade pip
-      run: |
-        python -m pip install --upgrade pip wheel
-    - name: Install Linux dependencies
-      if: "startsWith(runner.os, 'Linux')"
-      run: |
-        make install-deps-wxpython
     - name: Install conda
       uses: conda-incubator/setup-miniconda@v3
       with:
         environment-file: environments/eeg-expy-full.yml
-        auto-activate-base: true
-        python-version: 3.8
+        auto-activate-base: false
+        python-version: ${{ matrix.python_version }}
         activate-environment: eeg-expy-full
         channels: conda-forge
         miniconda-version: "latest"
-    - name: Install dependencies via conda
-      shell: bash -el {0}
+
+    - name: Recreate environment with osx-64 platform (macOS only)
+      if: matrix.os == 'macOS-latest'
       run: |
-        conda info
+        # Remove the osx-arm64 environment
+        conda deactivate
+        conda env remove -n eeg-expy-full --yes
+        
+        # Create osx-64 platform with audio support
+        conda create -v --platform osx-64 -n eeg-expy-full python=${PYTHON_VERSION}
         conda activate eeg-expy-full
+        conda env update -f environments/eeg-expy-full.yml
+      env:
+        PYTHON_VERSION: ${{ matrix.python_version }}
+
+
     - name: Run eegnb install test
-      shell: bash -el {0}
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
           Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> xvfb.log &
@@ -76,7 +69,6 @@ jobs:
         eegnb --help
         eegnb runexp --help
     - name: Run examples with coverage
-      shell: bash -el {0}
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
           Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> xvfb.log &
@@ -88,6 +80,9 @@ jobs:
   typecheck:
     name: typecheck (${{ matrix.os }}, py-${{ matrix.python_version }})
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:
@@ -96,24 +91,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
+    - name: Install conda
+      uses: conda-incubator/setup-miniconda@v3
       with:
+        environment-file: environments/eeg-expy-full.yml
+        auto-activate-base: false
         python-version: ${{ matrix.python_version }}
-    - name: Install APT dependencies
-      if: "startsWith(runner.os, 'Linux')"
-      run: |
-        make install-deps-apt
-    - name: Upgrade pip
-      run: |
-        python -m pip install --upgrade pip wheel
-    - name: Install Linux dependencies
-      if: "startsWith(runner.os, 'Linux')"
-      run: |
-        make install-deps-wxpython
-    - name: Install dependencies
-      run: |
-        make build
+        activate-environment: eeg-expy-full
+        channels: conda-forge
+        miniconda-version: "latest"
     - name: Typecheck
       run: |
         make typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,7 @@ jobs:
         os: ['ubuntu-22.04', windows-latest, macOS-latest]
         python_version: ['3.8']
         include:
-          # Experimental: Python 3.9
-          # Works fine, commented out because mostly covered (at least installing/building deps) by the typecheck job
-          # See issue: https://github.com/NeuroTechX/eeg-notebooks/issues/50
-          #- os: ubuntu-latest
-          #  python_version: 3.9
-
-          # Check 3.10 for future-proofing
+          # PsychoPy currently restricted to <= 3.10
           - os: ubuntu-22.04
             python_version: '3.10'
 

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -65,9 +65,13 @@ Use the following commands to download the repo, create and activate a conda or 
 
                cd eeg-expy
 
-               conda env create -v -f environments/eeg-expy-full.yml
+               # Specify newer python than 3.8 version if needed.
+               conda create -v -n eeg-expy-full python=3.8
 
                conda activate eeg-expy-full
+
+               # install only necessary dependencies
+               conda env update -f environments/eeg-expy-full.yml
 
           .. tab:: MacOS arm64(M1, M2, etc.)
 
@@ -81,10 +85,14 @@ Use the following commands to download the repo, create and activate a conda or 
 
                # for audio to be supported, osx-64 runtime is currently required,
                # drop the '--platform osx-64' parameter if audio is not needed, to use the native runtime.
-               conda env create -v --platform osx-64 -f environments/eeg-expy-full.yml
+               # Specify newer python than 3.8 version if needed.
+               conda create -v --platform osx-64 -n eeg-expy-full python=3.8
 
                # activate the environment
                conda activate eeg-expy-full
+
+               # install only necessary dependencies
+               conda env update -f environments/eeg-expy-full.yml
 
     .. tab:: Virtualenv
 

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -44,17 +44,22 @@ Use the following commands to download the repo, create and activate a conda or 
 
        .. tabs::
 
-            Available environment file options:
+            **Environment file options**
+
+
+            *Python 3.8 - 3.10:*
 
             - `eeg-expy-full`: Install all dependencies
 
-            - `eeg-expy-docsbuild`: Documentation
-
             - `eeg-expy-stimpres`: Stimulus presentation
 
-            - `eeg-expy-streaming`: Data streaming
-
             - `eeg-expy-streamstim`: Combined streaming and stimulus presentation
+
+            *Python 3.8 - 3.13:*
+
+            - `eeg-expy-docsbuild`: Documentation
+
+            - `eeg-expy-streaming`: Data streaming
 
 
           .. tab:: Windows, Linux or MacOS intel

--- a/eegnb/analysis/streaming_utils.py
+++ b/eegnb/analysis/streaming_utils.py
@@ -25,6 +25,7 @@ from scipy.signal import lfilter, lfilter_zi
 from eegnb import _get_recording_dir
 from eegnb.devices.eeg import EEG
 #from eegnb.devices.utils import EEG_INDICES, SAMPLE_FREQS
+from eegnb.analysis.utils import thres_stds
 
 # this should probably not be done here
 sns.set_context("talk")

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -25,6 +25,7 @@ from scipy.signal import lfilter, lfilter_zi
 from eegnb import _get_recording_dir
 from eegnb.devices.eeg import EEG
 from eegnb.devices.utils import EEG_INDICES, SAMPLE_FREQS
+from pynput import keyboard
 
 # this should probably not be done here
 sns.set_context("talk")
@@ -529,14 +530,22 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=None, th
             print(f"\n\nLooks like you still have {len(bad_channels)} bad channels after {loop_index+1} tries\n")
 
             prompt_time = time()
-            print(f"Starting next cycle in 5 seconds, press C and enter to cancel")    
+            print(f"Starting next cycle in 5 seconds, press C and enter to cancel")
+            c_key_pressed = False
+
+            def update_key_press(key):
+                if key.char == 'c':
+                    globals().update(c_key_pressed=True)
+            listener = keyboard.Listener(on_press=update_key_press)
+            listener.start()
             while time() < prompt_time + 5:  
-                if keyboard.is_pressed('c'): 
+                if c_key_pressed:
                     print("\nStopping signal quality checks!")
                     flag = True
-                    break  
+                    break
+            listener.stop()
         if flag: 
-            break  
+            break
             
 def fix_musemissinglines(orig_f,new_f=''):
 

--- a/eegnb/cli/__main__.py
+++ b/eegnb/cli/__main__.py
@@ -63,7 +63,7 @@ def runexp(
         eeg, experiment, recdur, outfname = intro_prompt()
     else:
         # Random values for outfile for now
-        outfname = generate_save_fn(eegdevice, experiment,7, 7)
+        outfname = str(generate_save_fn(str(eegdevice), experiment,7, 7))
         if eegdevice == "ganglion":
             # if the ganglion is chosen a MAC address should also be provided
             eeg = EEG(device=eegdevice, mac_addr=macaddr)

--- a/eegnb/cli/utils.py
+++ b/eegnb/cli/utils.py
@@ -7,7 +7,7 @@ prefs.hardware['audioLatencyMode'] = 3
 
 from eegnb.devices.eeg import EEG
 
-from eegnb.experiments import VisualN170
+from eegnb.experiments import VisualN170, Experiment
 from eegnb.experiments import VisualP300
 from eegnb.experiments import VisualSSVEP
 from eegnb.experiments import AuditoryOddball
@@ -47,7 +47,7 @@ def run_experiment(
         module = experiments[experiment]
 
         # Condition added for different run types of old and new experiment class structure
-        if experiment == "visual-N170" or experiment == "visual-P300" or experiment == "visual-SSVEP" or experiment == "auditory-oddball orig":
+        if isinstance(module, Experiment.BaseExperiment):
             module.duration = record_duration
             module.eeg = eeg_device
             module.save_fn = save_fn

--- a/eegnb/experiments/visual_vep/vep.py
+++ b/eegnb/experiments/visual_vep/vep.py
@@ -14,10 +14,10 @@ class VisualVEP(Experiment.BaseExperiment):
         exp_name = "Visual VEP"
         super().__init__(exp_name, duration, eeg, save_fn, n_trials, iti, soa, jitter)
 
-    def load_stimulus():
+    def load_stimulus(self):
         pass
     
-    def present_stimulus():
+    def present_stimulus(self, idx: int):
         pass
 
 

--- a/environments/eeg-expy-docsbuild.yml
+++ b/environments/eeg-expy-docsbuild.yml
@@ -3,7 +3,6 @@ channels:
     - conda-forge
 dependencies:
     # System-level dependencies
-    - python=3.8
     - pytables # install pytables for macOS arm64, so do not need to build from source.
     - rust # used by docsbuild
     - pip

--- a/environments/eeg-expy-docsbuild.yml
+++ b/environments/eeg-expy-docsbuild.yml
@@ -3,6 +3,7 @@ channels:
     - conda-forge
 dependencies:
     # System-level dependencies
+    - python>=3.8,<=3.13
     - pytables # install pytables for macOS arm64, so do not need to build from source.
     - rust # used by docsbuild
     - pip

--- a/environments/eeg-expy-full.yml
+++ b/environments/eeg-expy-full.yml
@@ -3,11 +3,13 @@ channels:
     - conda-forge
 dependencies:
     # System-level dependencies
+    - python>=3.8,<=3.10 # psychopy <= 3.10
+    - dukpy==0.2.3 # psychopy dependency, avoid failing due to building wheel on win 3.9.
     - pytables # install pytables for macOS arm64, so do not need to build from source.
     - rust # used by docsbuild
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
-    - html2text
+    - html2text # avoid building wheel
     - pip
     - pip:
       # Install package with only Analysis requirements

--- a/environments/eeg-expy-full.yml
+++ b/environments/eeg-expy-full.yml
@@ -8,7 +8,6 @@ dependencies:
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
     - html2text
-    - ffpyplayer
     - pip
     - pip:
       # Install package with only Analysis requirements

--- a/environments/eeg-expy-full.yml
+++ b/environments/eeg-expy-full.yml
@@ -7,6 +7,9 @@ dependencies:
     - rust # used by docsbuild
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
+    - psychopy
+    - html2text
+    - ffpyplayer
     - pip
     - pip:
       # Install package with only Analysis requirements

--- a/environments/eeg-expy-full.yml
+++ b/environments/eeg-expy-full.yml
@@ -3,7 +3,6 @@ channels:
     - conda-forge
 dependencies:
     # System-level dependencies
-    - python=3.8
     - pytables # install pytables for macOS arm64, so do not need to build from source.
     - rust # used by docsbuild
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."

--- a/environments/eeg-expy-full.yml
+++ b/environments/eeg-expy-full.yml
@@ -7,7 +7,6 @@ dependencies:
     - rust # used by docsbuild
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
-    - psychopy
     - html2text
     - ffpyplayer
     - pip

--- a/environments/eeg-expy-stimpres.yml
+++ b/environments/eeg-expy-stimpres.yml
@@ -3,6 +3,8 @@ channels:
     - conda-forge
 dependencies:
     # System-level dependencies
+    - python>=3.8,<=3.10 # psychopy <= 3.10
+    - dukpy==0.2.3 # psychopy dependency, avoid failing due to building wheel on win 3.9.
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
     - pip
     - pip:

--- a/environments/eeg-expy-stimpres.yml
+++ b/environments/eeg-expy-stimpres.yml
@@ -3,7 +3,6 @@ channels:
     - conda-forge
 dependencies:
     # System-level dependencies
-    - python=3.8
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
     - pip
     - pip:

--- a/environments/eeg-expy-streaming.yml
+++ b/environments/eeg-expy-streaming.yml
@@ -3,7 +3,6 @@ channels:
     - conda-forge
 dependencies:
     # System-level dependencies
-    - python=3.8
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - pip
     - pip:

--- a/environments/eeg-expy-streaming.yml
+++ b/environments/eeg-expy-streaming.yml
@@ -3,6 +3,7 @@ channels:
     - conda-forge
 dependencies:
     # System-level dependencies
+    - python>=3.8,<=3.13
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - pip
     - pip:

--- a/environments/eeg-expy-streamstim.yml
+++ b/environments/eeg-expy-streamstim.yml
@@ -4,7 +4,6 @@ channels:
     - defaults
 dependencies:
     # System-level dependencies
-    - python=3.8
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
     - pip

--- a/environments/eeg-expy-streamstim.yml
+++ b/environments/eeg-expy-streamstim.yml
@@ -4,6 +4,8 @@ channels:
     - defaults
 dependencies:
     # System-level dependencies
+    - python>=3.8,<=3.10 # psychopy <= 3.10
+    - dukpy==0.2.3 # psychopy dependency, avoid failing due to building wheel on win 3.9.
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
     - pip

--- a/examples/visual_n170/02r__n170_decoding.py
+++ b/examples/visual_n170/02r__n170_decoding.py
@@ -127,7 +127,7 @@ for m in clfs:
 results = pd.DataFrame(data=auc, columns=['AUC'])
 results['Method'] = methods
 
-fig = plt.figure(figsize=[8,4])
+fig = plt.figure(figsize=(8, 4))
 sns.barplot(data=results, x='AUC', y='Method')
 plt.xlim(0.4, 0.9)
 sns.despine()

--- a/examples/visual_p300/02r__p300_decoding.py
+++ b/examples/visual_p300/02r__p300_decoding.py
@@ -118,7 +118,7 @@ for m in clfs:
 results = pd.DataFrame(data=auc, columns=['AUC'])
 results['Method'] = methods
 
-plt.figure(figsize=[8,4])
+plt.figure(figsize=(8, 4))
 sns.barplot(data=results, x='AUC', y='Method')
 plt.xlim(0.2, 0.85)
 sns.despine()

--- a/examples/visual_ssvep/02r__ssvep_decoding.py
+++ b/examples/visual_ssvep/02r__ssvep_decoding.py
@@ -151,7 +151,7 @@ for m in clfs:
 results = pd.DataFrame(data=auc, columns=['AUC'])
 results['Method'] = methods
 
-fig = plt.figure(figsize=[8,4])
+fig = plt.figure(figsize=(8, 4))
 sns.barplot(data=results, x='AUC', y='Method')
 plt.xlim(0.4, 1)
 sns.despine()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@
 
 scikit-learn>=0.23.2
 pandas>=1.1.4
-numpy>=1.26.0  # 3.13 compatible
+numpy>=1.26.0;  python_version >= "3.9"
+numpy<=1.24.4; python_version == "3.8"
 mne>=0.20.8
 seaborn>=0.11.0
 pyriemann>=0.2.7
@@ -57,7 +58,8 @@ ffpyplayer==4.5.2 # 4.5.3 fails to build as wheel.
 psychtoolbox
 scikit-learn>=0.23.2
 pandas>=1.1.4
-numpy>=1.26.0  # 3.13 compatible
+numpy>=1.26.0;  python_version >= "3.9"
+numpy==1.24.4; python_version == "3.8"
 mne>=0.20.8
 seaborn>=0.11.0
 pysocks>=1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ click
 pyobjc==7.3; sys_platform == 'darwin'
 #upgrade psychopy to use newer wxpython dependency which is prebuilt for m1 support.
 psychopy==2023.2.2
+ffpyplayer==4.5.2 # 4.5.3 fails to build as wheel.
 psychtoolbox
 scikit-learn>=0.23.2
 pandas>=1.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 scikit-learn>=0.23.2
 pandas>=1.1.4
-numpy>=1.19.4,<1.24  # due to outdated libs not changing the names after: https://github.com/numpy/numpy/pull/22607
+numpy>=1.26.0  # 3.13 compatible
 mne>=0.20.8
 seaborn>=0.11.0
 pyriemann>=0.2.7
@@ -57,7 +57,7 @@ ffpyplayer==4.5.2 # 4.5.3 fails to build as wheel.
 psychtoolbox
 scikit-learn>=0.23.2
 pandas>=1.1.4
-numpy>=1.19.4,<1.24  # due to outdated libs not changing the names after: https://github.com/numpy/numpy/pull/22607
+numpy>=1.26.0  # 3.13 compatible
 mne>=0.20.8
 seaborn>=0.11.0
 pysocks>=1.7.1
@@ -78,8 +78,10 @@ pywinhook @ https://github.com/ActivityWatch/wheels/raw/master/pywinhook/pyWinho
 # See issue: https://github.com/psychopy/psychopy/issues/2876
 pyglet==1.4.11 ; platform_system == "Windows"
 
-# Oculus/Quest VR support - currently only supported on Windows.
-psychxr>=0.2.4rc2; platform_system == "Windows"
+# Oculus/Quest VR support - currently only supported on Windows and
+# <= 3.9, otherwise will need Oculus PC SDK to build wheel.
+psychxr>=0.2.4rc2; platform_system == "Windows" and python_version <= "3.9"
+
 
 
 


### PR DESCRIPTION
* improved build speeds
* fixed type check test to pass.
* fixed ci macos build by using osx-x64 platform.
* allow conda environment to build on versions of python higher than 3.8.
* build ci test workflow on dev/* branches.
* pinned ffpyplayer version to prevent wheel build error.
* updated doc to better support other python versions with conda.
TODO in future pull requests:
* get osx full dependencies building on python > 3.8
* update docs.yml to use same conda build pipeline
* build all supported python versions for all supported os's as part of test.yml