### PR TITLE
Apple silicon native sound support

### DIFF
--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -10,11 +10,7 @@ obj.run()
 
 from abc import abstractmethod
 from typing import Callable
-from psychopy import prefs
 from psychopy.visual.rift import Rift
-#change the pref libraty to PTB and set the latency mode to high precision
-prefs.hardware['audioLib'] = 'PTB'
-prefs.hardware['audioLatencyMode'] = 3
 
 from time import time
 import random

--- a/eegnb/experiments/__init__.py
+++ b/eegnb/experiments/__init__.py
@@ -2,9 +2,26 @@ from .visual_n170.n170 import VisualN170
 from .visual_p300.p300 import VisualP300
 from .visual_ssvep.ssvep import VisualSSVEP
 
-# PTB does not yet support macOS Apple Silicon,
-# this experiment needs to run as i386 if on macOS.
-import sys
+from psychopy import sound, plugins, prefs
 import platform
-if sys.platform != 'darwin' or platform.processor() != 'arm':
-    from .auditory_oddball.aob import AuditoryOddball
+
+# PTB does not yet support macOS Apple Silicon freely, need to fall back to sounddevice.
+if platform.system() == 'Darwin' and platform.machine() == 'arm64':
+    # import psychopy_sounddevice.backend_sounddevice
+    plugins.scanPlugins()
+    success = plugins.loadPlugin('psychopy-sounddevice')
+    print(f"psychopy_sounddevice plugin loaded: {success}")
+
+    # Force reload sound module
+    import importlib
+    importlib.reload(sound)
+    # setting prefs.hardware['audio_device'] still falls back to a default device, need to use setDevice.
+    audio_device = prefs.hardware.get('audioDevice', 'default')
+    if audio_device and audio_device != 'default':
+        sound.setDevice(audio_device)
+else:
+    #change the pref library to PTB and set the latency mode to high precision
+    prefs.hardware['audioLib'] = 'PTB'
+    prefs.hardware['audioLatencyMode'] = 3
+
+from .auditory_oddball.aob import AuditoryOddball

--- a/eegnb/experiments/auditory_oddball/auditory_erp_arrayin.py
+++ b/eegnb/experiments/auditory_oddball/auditory_erp_arrayin.py
@@ -1,11 +1,6 @@
 """Generate sound-only auditory oddball stimulus presentation.
 """
 
-from psychopy import prefs
-#change the pref libraty to PTB and set the latency mode to high precision
-prefs.hardware['audioLib'] = 'PTB'
-prefs.hardware['audioLatencyMode'] = 3
-
 import time
 from optparse import OptionParser
 

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -1,10 +1,5 @@
 """  eeg-notebooks/eegnb/experiments/visual_n170/n170.py """
 
-from psychopy import prefs
-#change the pref libraty to PTB and set the latency mode to high precision
-prefs.hardware['audioLib'] = 'PTB'
-prefs.hardware['audioLatencyMode'] = 3
-
 import os
 from time import time
 from glob import glob

--- a/eegnb/experiments/visual_n170/n170_fixedstimorder.py
+++ b/eegnb/experiments/visual_n170/n170_fixedstimorder.py
@@ -6,11 +6,6 @@ Face vs. house paradigm stimulus presentation for evoking present.
 
 """
 
-from psychopy import prefs
-#change the pref libraty to PTB and set the latency mode to high precision
-prefs.hardware['audioLib'] = 'PTB'
-prefs.hardware['audioLatencyMode'] = 3
-
 from time import time
 from optparse import OptionParser
 import os

--- a/environments/eeg-expy-full.yml
+++ b/environments/eeg-expy-full.yml
@@ -10,6 +10,7 @@ dependencies:
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
     - html2text # avoid building wheel
+    - cffi # Fix sound ffi.callback() issue with sounddevice on macOS: https://github.com/spatialaudio/python-sounddevice/issues/397
     - pip
     - pip:
       # Install package with only Analysis requirements

--- a/environments/eeg-expy-stimpres.yml
+++ b/environments/eeg-expy-stimpres.yml
@@ -6,6 +6,7 @@ dependencies:
     - python>=3.8,<=3.10 # psychopy <= 3.10
     - dukpy==0.2.3 # psychopy dependency, avoid failing due to building wheel on win 3.9.
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
+    - cffi # Fix sound ffi.callback() issue with sounddevice on macOS: https://github.com/spatialaudio/python-sounddevice/issues/397
     - pip
     - pip:
       # Install package with Analysis + Streaming requirements

--- a/psychopy-sounddevice/.gitignore
+++ b/psychopy-sounddevice/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/psychopy-sounddevice/LICENSE
+++ b/psychopy-sounddevice/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/psychopy-sounddevice/README.md
+++ b/psychopy-sounddevice/README.md
@@ -1,0 +1,17 @@
+# psychopy-sounddevice
+
+Audio playback backend using the [SoundDevice](https://python-sounddevice.readthedocs.io) library.
+
+## Installing
+
+Install this package with the following shell command:: 
+
+    pip install psychopy-sounddevice
+
+You may also use PsychoPy's builtin package manager to install this package.
+
+## Usage
+
+Once the package is installed, PsychoPy will automatically load it when started and make objects available within the
+`psychopy.sound.backend_sounddevice` namespace. You can select the backend to use for a session by specifying 
+`'sounddevice'` in "Hardware" > "audio library" prefs. 

--- a/psychopy-sounddevice/psychopy_sounddevice/__init__.py
+++ b/psychopy-sounddevice/psychopy_sounddevice/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Originally from the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+"""Audio backend for playback using SoundDevice.
+"""
+
+__version__ = '0.0.1'
+
+from .backend_sounddevice import (
+    init,
+    getDevices,
+    getStreamLabel,
+    SoundDeviceSound)
+

--- a/psychopy-sounddevice/psychopy_sounddevice/backend_sounddevice.py
+++ b/psychopy-sounddevice/psychopy_sounddevice/backend_sounddevice.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+__all__ = [
+    'init',
+    'getDevices',
+    'getStreamLabel',
+    'SoundDeviceSound'
+]
+
+import sys
+import os
+import time
+import re
+import atexit
+
+try:
+    import readline  # Work around GH-2230
+except ImportError:
+    pass  # all that will happen is the stderr/stdout might get redirected
+
+from psychopy import logging
+from psychopy.constants import (PLAYING, PAUSED, FINISHED, STOPPED,
+                                NOT_STARTED)
+from psychopy.sound.exceptions import SoundFormatError, DependencyError
+from psychopy.sound._base import _SoundBase, HammingWindow
+
+try:
+    import sounddevice as sd
+except (ImportError, OSError):
+    raise DependencyError("sounddevice not working")
+try:
+    import soundfile as sf
+except (ImportError, OSError):
+    raise DependencyError("soundfile not working")
+
+import numpy as np
+
+travisCI = bool(str(os.environ.get('TRAVIS')).lower() == 'true')
+
+logging.info("Loaded SoundDevice with {}".format(sd.get_portaudio_version()[1]))
+
+
+def init(rate=44100, stereo=True, buffer=128):
+    pass  # for compatibility with other backends
+
+
+def getDevices(kind=None):
+    """Returns a dict of dict of audio devices of specified `kind`
+
+    The dict keys are names and items are dicts of properties
+    """
+    devs = {}
+    if travisCI:  # travis-CI testing does not have a sound device
+        return devs
+    else:
+        allDevs = sd.query_devices(kind=kind)
+    # annoyingly query_devices is a DeviceList or a dict depending on number
+    if type(allDevs) == dict:
+        allDevs = [allDevs]
+    for ii, dev in enumerate(allDevs):
+        # newline characters must be removed
+        devName = dev['name'].replace('\r\n','')
+        devs[devName] = dev
+        dev['id'] = ii
+    return devs
+
+
+# these will be controlled by sound.__init__.py
+defaultInput = None
+defaultOutput = None
+
+
+def getStreamLabel(sampleRate, channels, blockSize):
+    """Returns the string repr of the stream label
+    """
+    return "{}_{}_{}".format(sampleRate, channels, blockSize)
+
+
+class _StreamsDict(dict):
+    """Keeps track of what streams have been created. On macOS we can have
+    multiple streams under portaudio but under windows we can only have one.
+
+    use the instance `streams` rather than creating a new instance of this
+    """
+
+    def getStream(self, sampleRate, channels, blockSize):
+        """Gets a stream of exact match or returns a new one
+        (if possible for the current operating system)
+        """
+        # if the query looks flexible then try getSimilar
+        if channels == -1 or blockSize == -1:
+            return self._getSimilar(sampleRate,
+                                    channels=channels,
+                                    blockSize=blockSize)
+        else:
+            return self._getStream(sampleRate,
+                                   channels=channels,
+                                   blockSize=blockSize)
+
+    def _getSimilar(self, sampleRate, channels=-1, blockSize=-1):
+        """Do we already have a compatible stream?
+
+        Many sounds can allow channels and blocksize to change but samplerate
+        is generally fixed. Any values set to -1 above will be flexible. Any
+        values set to an alternative number will be fixed
+
+        usage:
+
+            label, stream = streams._getSimilar(sampleRate=44100,  # must match
+                                               channels=-1,  # any
+                                               blockSize=-1)  # wildcard
+        """
+        label = getStreamLabel(sampleRate, channels, blockSize)
+        # replace -1 with any regex integer
+        simil = re.compile(label.replace("-1", r"[-+]?(\d+)"))  # I hate REGEX!
+        for thisFormat in self:
+            if simil.match(thisFormat):  # we found a close-enough match
+                return thisFormat, self[thisFormat]
+        # if we've been given values in each place then create stream
+        if (sampleRate not in [None, -1, 0] and
+                    channels not in [None, -1] and
+                    blockSize not in [None, -1]):
+            return self._getStream(sampleRate, channels, blockSize)
+
+    def _getStream(self, sampleRate, channels, blockSize):
+        """Strict check for this format or create new
+        """
+        label = getStreamLabel(sampleRate, channels, blockSize)
+        # try to retrieve existing stream of that name
+        if label in self:
+            pass
+        # on some systems more than one stream isn't supported so check
+        elif sys.platform == 'win32' and len(self):
+            raise SoundFormatError(
+                "Tried to create audio stream {} but {} already exists "
+                "and {} doesn't support multiple portaudio streams"
+                    .format(label, list(self.keys())[0], sys.platform)
+            )
+        else:
+            # create new stream
+            self[label] = _SoundStream(sampleRate, channels, blockSize,
+                                       device=defaultOutput)
+        return label, self[label]
+
+
+streams = _StreamsDict()
+
+
+class _SoundStream:
+    def __init__(self, sampleRate, channels, blockSize,
+                 device=None, duplex=False):
+        # initialise thread
+        self.streams = []
+        self.list = []
+        # sound stream info
+        self.sampleRate = sampleRate
+        self.channels = channels
+        self.duplex = duplex
+        self.blockSize = blockSize
+        self.label = getStreamLabel(sampleRate, channels, blockSize)
+        if device == 'default':
+            device = None
+        self.sounds = []  # list of dicts for sounds currently playing
+        self.takeTimeStamp = False
+        self.frameN = 1
+        # self.frameTimes = range(5)  # DEBUGGING: store the last 5 callbacks
+        if not travisCI:  # travis-CI testing does not have a sound device
+            self._sdStream = sd.OutputStream(samplerate=self.sampleRate,
+                                             blocksize=self.blockSize,
+                                             latency='low',
+                                             device=device,
+                                             channels=self.channels,
+                                             callback=self.callback)
+            self._sdStream.start()
+            self.device = self._sdStream.device
+            self.latency = self._sdStream.latency
+            self.cpu_load = self._sdStream.cpu_load
+            atexit.register(self.__del__)
+        self._tSoundRequestPlay = 0
+
+        self._isPlaying = False
+
+    @property
+    def isPlaying(self):
+        """`True` if the audio playback is ongoing."""
+        return self._isPlaying
+
+    def callback(self, toSpk, blockSize, timepoint, status):
+        """This is a callback for the SoundDevice lib
+
+        fromMic is data from the mic that can be extracted
+        toSpk is a numpy array to be populated with data
+        blockSize is the number of frames to be included each block
+        timepoint has values:
+            .currentTime
+            .inputBufferAdcTime
+            .outputBufferDacTime
+        """
+        if self.takeTimeStamp and hasattr(self, 'lastFrameTime'):
+            logging.info("Entered callback: {} ms after last frame end"
+                         .format((time.time() - self.lastFrameTime) * 1000))
+            logging.info("Entered callback: {} ms after sound start"
+                         .format(
+                (time.time() - self._tSoundRequestPlay) * 1000))
+        t0 = time.time()
+        self.frameN += 1
+        toSpk.fill(0)
+        for thisSound in list(self.sounds): # copy (Py2 doesn't have list.copy)
+            dat = thisSound._nextBlock()  # fetch the next block of data
+            dat *= thisSound.volume  # Set the volume block by block
+            if self.channels == 2 and len(dat.shape) == 2:
+                toSpk[:len(dat), :] += dat  # add to out stream
+            elif self.channels == 2 and len(dat.shape) == 1:
+                toSpk[:len(dat), 0] += dat  # add to out stream
+                toSpk[:len(dat), 1] += dat  # add to out stream
+            elif self.channels == 1 and len(dat.shape) == 2:
+                toSpk[:len(dat), :] += dat  # add to out stream
+            else:
+                toSpk[:len(dat), 0:self.channels] += dat  # add to out stream
+            # check if that was a short block (sound is finished)
+            if len(dat) < len(toSpk[:, :]):
+                self.remove(thisSound)
+                thisSound._EOS()
+                # check if that took a long time
+                # t1 = time.time()
+                # if (t1-t0) > 0.001:
+                #     logging.debug("buffer_callback took {:.3f}ms that frame"
+                #                  .format((t1-t0)*1000))
+                # self.frameTimes.pop(0)
+                # if hasattr(self, 'lastFrameTime'):
+                #     self.frameTimes.append(time.time()-self.lastFrameTime)
+                # self.lastFrameTime = time.time()
+                # if self.takeTimeStamp:
+                #     logging.debug("Callback durations: {}".format(self.frameTimes))
+                #     self.takeTimeStamp = False
+
+    def add(self, sound):
+        # t0 = time.time()
+        self.sounds.append(sound)
+        # logging.debug("took {} ms to add".format((time.time()-t0)*1000))
+
+    def remove(self, sound):
+        if sound in self.sounds:
+            self.sounds.remove(sound)
+
+    def __del__(self):
+        if hasattr(self, '_sdStream'):
+            if not travisCI:
+                self._sdStream.stop()
+            del self._sdStream
+        if hasattr(sys, 'stdout'):
+            sys.stdout.flush()
+        atexit.unregister(self.__del__)
+
+
+class SoundDeviceSound(_SoundBase):
+    """Play a variety of sounds using the new SoundDevice library
+    """
+
+    def __init__(self, value="C", secs=0.5, octave=4, stereo=-1,
+                 speaker=None,
+                 volume=1.0, loops=0,
+                 sampleRate=None, blockSize=128,
+                 preBuffer=-1,
+                 hamming=True,
+                 startTime=0, stopTime=-1,
+                 name='', autoLog=True):
+        """
+        :param value: note name ("C","Bfl"), filename or frequency (Hz)
+        :param secs: duration (for synthesised tones)
+        :param octave: which octave to use for note names (4 is middle)
+        :param stereo: -1 (auto), True or False
+                        to force sounds to stereo or mono
+        :param volume: float 0-1
+        :param loops: number of loops to play (-1=forever, 0=single repeat)
+        :param sampleRate: sample rate (for synthesized tones)
+        :param blockSize: the size of the buffer on the sound card
+                         (small for low latency, large for stability)
+        :param preBuffer: integer to control streaming/buffering
+                           - -1 means store all
+                           - 0 (no buffer) means stream from disk
+                           - potentially we could buffer a few secs(!?)
+        :param hamming: boolean (default True) to indicate if the sound should
+                        be apodized (i.e., the onset and offset smoothly ramped up from
+                        down to zero). The function apodize uses a Hanning window, but
+                        arguments named 'hamming' are preserved so that existing code
+                        is not broken by the change from Hamming to Hanning internally.
+                        Not applied to sounds from files.
+        :param startTime: for sound files this controls the start of snippet
+        :param stopTime: for sound files this controls the end of snippet
+        :param name: string for logging purposes
+        :param autoLog: whether to automatically log every change
+        """
+        self.sound = value
+        self.speaker = speaker
+        self.name = name
+        self.secs = secs  # for any synthesised sounds (notesand freqs)
+        self.octave = octave  # for note name sounds
+        self.loops = loops
+        self._loopsFinished = 0
+        self.volume = volume
+        self.startTime = startTime  # for files
+        self.stopTime = stopTime  # for files specify thesection to be played
+        self.blockSize = blockSize  # can be per-sound unlike other backends
+        self.preBuffer = preBuffer
+        self.frameN = 0
+        self._tSoundRequestPlay = 0
+        if sampleRate:  #a rate was requested so use it
+            self.sampleRate = sampleRate
+        else:  # no requested rate so use current stream or a default of 44100
+            rate = 44100  # start with a default
+            for streamLabel in streams:  # then look to see if we have an open stream and use that
+                rate = streams[streamLabel].sampleRate
+            self.sampleRate = rate
+        self.stereo = stereo
+        if isinstance(value, np.ndarray):
+            self.channels = value.shape[1]  # let this be set by stereo
+        self.multichannel = False
+        self.duplex = None
+        self.autoLog = autoLog
+        self.streamLabel = ""
+        self.sourceType = 'unknown'  # set to be file, array or freq
+        self.sndFile = None
+        self.sndArr = None
+        self.hamming = hamming
+        self._hammingWindow = None  # will be created during setSound
+
+        # setSound (determines sound type)
+        self.setSound(value, secs=self.secs, octave=self.octave,
+                      hamming=self.hamming)
+        self.status = NOT_STARTED
+
+        self._isPlaying = False
+
+    @property
+    def isPlaying(self):
+        """`True` if the audio playback is ongoing."""
+        return self._isPlaying
+
+    @property
+    def stereo(self):
+        return self.__dict__['stereo']
+
+    @stereo.setter
+    def stereo(self, val):
+        self.__dict__['stereo'] = val
+        if val is True:
+            self.__dict__['channels'] = 2
+        elif val is False:
+            self.__dict__['channels'] = 1
+        elif val == -1:
+            self.__dict__['channels'] = -1
+
+    def setSound(self, value, secs=0.5, octave=4, hamming=None, log=True):
+        """Set the sound to be played.
+
+        Often this is not needed by the user - it is called implicitly during
+        initialisation.
+
+        :parameters:
+
+            value: can be a number, string or an array:
+                * If it's a number between 37 and 32767 then a tone will
+                  be generated at that frequency in Hz.
+                * It could be a string for a note ('A', 'Bfl', 'B', 'C',
+                  'Csh'. ...). Then you may want to specify which octave.
+                * Or a string could represent a filename in the current
+                  location, or mediaLocation, or a full path combo
+                * Or by giving an Nx2 numpy array of floats (-1:1) you can
+                  specify the sound yourself as a waveform
+
+            secs: duration (only relevant if the value is a note name or
+                a frequency value)
+
+            octave: is only relevant if the value is a note name.
+                Middle octave of a piano is 4. Most computers won't
+                output sounds in the bottom octave (1) and the top
+                octave (8) is generally painful
+        """
+        # start with the base class method
+        _SoundBase.setSound(self, value, secs, octave, hamming, log)
+        try:
+            label, s = streams.getStream(sampleRate=self.sampleRate,
+                                         channels=self.channels,
+                                         blockSize=self.blockSize)
+        except SoundFormatError as err:
+            # try to use something similar (e.g. mono->stereo)
+            # then check we have an appropriate stream open
+            altern = streams._getSimilar(sampleRate=self.sampleRate,
+                                         channels=-1,
+                                         blockSize=-1)
+            if altern is None:
+                raise err
+            else:  # safe to extract data
+                label, s = altern
+            # update self in case it changed to fit the stream
+            self.sampleRate = s.sampleRate
+            self.channels = s.channels
+            self.blockSize = s.blockSize
+        self.streamLabel = label
+
+        if hamming is None:
+            hamming = self.hamming
+        else:
+            self.hamming = hamming
+        if hamming:
+            # 5ms or 15th of stimulus (for short sounds)
+            hammDur = min(0.005,  # 5ms
+                          self.secs / 15.0)  # 15th of stim
+            self._hammingWindow = HammingWindow(winSecs=hammDur,
+                                                soundSecs=self.secs,
+                                                sampleRate=self.sampleRate)
+
+    def _setSndFromClip(self, clip):
+        if self.channels == -1:
+            if self.stereo == 0:
+                self.channels = 1
+            elif self.stereo == 1:
+                self.channels = 2
+
+        thisArray = clip.samples
+
+        self.sndArr = np.asarray(thisArray)
+        if thisArray.ndim == 1:
+            self.sndArr.shape = [len(thisArray), 1]  # make 2D for broadcasting
+        if self.channels == 2 and self.sndArr.shape[1] == 1:  # mono -> stereo
+            self.sndArr = self.sndArr.repeat(2, axis=1)
+        elif self.sndArr.shape[1] == 1:  # if channels in [-1,1] then pass
+            pass
+        else:
+            try:
+                self.sndArr.shape = [len(thisArray), self.channels]
+            except ValueError:
+                raise ValueError("Failed to format sound with shape {} "
+                                 "into sound with channels={}"
+                                 .format(self.sndArr.shape, self.channels))
+
+        # is this stereo?
+        if self.stereo == -1:  # auto stereo. Try to detect
+            if self.sndArr.shape[1] == 1:
+                self.stereo = 0
+            elif self.sndArr.shape[1] == 2:
+                self.stereo = 1
+            elif self.sndArr.shape[1] >= 2:
+                self.multichannel = True
+                # raise IOError("Couldn't determine whether array is "
+                #               "stereo. Shape={}".format(self.sndArr.shape))
+        self._nSamples = thisArray.shape[0]
+        if self.stopTime == -1:
+            self.duration = self._nSamples/float(self.sampleRate)
+        else:
+            self.duration = self.secs
+        # set to run from the start:
+        self.seek(0)
+        self.sourceType = "array"
+
+    def _channelCheck(self, array):
+        """Checks whether stream has fewer channels than data. If True, ValueError"""
+        if self.channels < array.shape[1]:
+            msg = ("The sound stream is set up incorrectly. You have fewer channels in the buffer "
+                   "than in data file ({} vs {}).\n**Ensure you have selected 'Force stereo' in "
+                   "experiment settings**".format(self.channels, array.shape[1]))
+            logging.error(msg)
+            raise ValueError(msg)
+
+    def play(self, loops=None, when=None):
+        """Start the sound playing
+
+        Parameters
+        --------------
+            when: not used
+                Included for compatibility purposes
+        """
+        if self.isPlaying:
+            return
+
+        if loops is not None and self.loops != loops:
+            self.setLoops(loops)
+        self._isPlaying = True
+        self._tSoundRequestPlay = time.time()
+        streams[self.streamLabel].takeTimeStamp = True
+        streams[self.streamLabel].add(self)
+
+    def pause(self):
+        """Stop the sound but play will continue from here if needed
+        """
+        # if self.status == PAUSED:
+        #     return
+        #
+        # self.status = PAUSED
+        streams[self.streamLabel].remove(self)
+
+    def stop(self, reset=True):
+        """Stop the sound and return to beginning
+        """
+        if not self.isPlaying:
+            return
+
+        streams[self.streamLabel].remove(self)
+        if reset:
+            self.seek(0)
+        self._isPlaying = False
+
+    def _nextBlock(self):
+        if not self.isPlaying:
+            return
+        samplesLeft = int((self.duration - self.t) * self.sampleRate)
+        nSamples = min(self.blockSize, samplesLeft)
+        if self.sourceType == 'file' and self.preBuffer == 0:
+            # streaming sound block-by-block direct from file
+            block = self.sndFile.read(nSamples)
+            # TODO: check if we already finished using sndFile?
+        elif (self.sourceType == 'file' and self.preBuffer == -1) \
+                or self.sourceType == 'array':
+            # An array, or a file entirely loaded into an array
+            ii = int(round(self.t * self.sampleRate))
+            if self.stereo == 1 or self.multichannel:  # don't treat as boolean. Might be -1
+                block = self.sndArr[ii:ii + nSamples, :]
+            elif self.stereo == 0:
+                block = self.sndArr[ii:ii + nSamples]
+            else:
+                raise IOError("Unknown stereo type {!r}"
+                              .format(self.stereo))
+            if ii + nSamples > len(self.sndArr):
+                self._EOS()
+
+        elif self.sourceType == 'freq':
+            startT = self.t
+            stopT = self.t + self.blockSize/float(self.sampleRate)
+            xx = np.linspace(
+                start=startT * self.freq * 2 * np.pi,
+                stop=stopT * self.freq * 2 * np.pi,
+                num=self.blockSize, endpoint=False
+            )
+            xx.shape = [self.blockSize, 1]
+            block = np.sin(xx)
+            # if run beyond our desired t then set to zeros
+            if stopT > (self.secs):
+                tRange = np.linspace(startT, self.blockSize*self.sampleRate,
+                                     num=self.blockSize, endpoint=False)
+                block[tRange > self.secs] = 0
+                # and inform our EOS function that we finished
+                self._EOS(reset=False)  # don't set t=0
+
+        else:
+            raise IOError("SoundDeviceSound._nextBlock doesn't correctly handle"
+                          "{!r} sounds yet".format(self.sourceType))
+
+        if self._hammingWindow:
+            thisWin = self._hammingWindow.nextBlock(self.t, self.blockSize)
+            if thisWin is not None:
+                if len(block) == len(thisWin):
+                    block *= thisWin
+                elif block.shape[0] == 0:
+                    pass
+                else:
+                    block *= thisWin[0:len(block)]
+        self.t += self.blockSize/float(self.sampleRate)
+        return block
+
+    def seek(self, t):
+        self.t = t
+        self.frameN = int(round(t * self.sampleRate))
+        if self.sndFile and not self.sndFile.closed:
+            self.sndFile.seek(self.frameN)
+
+    def _EOS(self, reset=True):
+        """Function called on End Of Stream
+        """
+        self._loopsFinished += 1
+        if self.loops == 0:
+            self.stop(reset=reset)
+        elif self.loops > 0 and self._loopsFinished >= self.loops:
+            self.stop(reset=reset)
+
+        streams[self.streamLabel].remove(self)
+        self._isPlaying = False
+
+    @property
+    def stream(self):
+        """Read-only property returns the the stream on which the sound
+        will be played
+        """
+        return streams[self.streamLabel]
+    
+        
+    def _setSndFromArrayLegacy(self, thisArray):
+        """
+        Prior to 2025.1.0, _SoundBase didn't have a `_setSndFromArray` method to inherit. This legacy method can be substituted in if the version of PsychoPy installed is too old.
+        """
+        from psychopy.sound.audioclip import AudioClip
+        clip = AudioClip(thisArray, sampleRateHz=self.sampleRate)
+        self._setSndFromClip(clip)
+
+
+if not hasattr(SoundDeviceSound, "_setSndFromArray"):
+    SoundDeviceSound._setSndFromArray = SoundDeviceSound._setSndFromArrayLegacy
+
+
+if __name__ == "__main__":
+    pass

--- a/psychopy-sounddevice/pyproject.toml
+++ b/psychopy-sounddevice/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "psychopy-sounddevice"
+version = "0.0.1"
+description = "Extension for using SoundDevice for audio playback."
+readme = "README.md"
+requires-python = ">= 3.7"
+license = {text = "GNU General Public License v3 (GPLv3)"}
+authors = [
+  { name = "Jon Peirce", email = "jon@opensceincetools.org" },
+  { name = "Matthew Cutone", email = "mcutone@opensceincetools.org" },
+]
+classifiers = [
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: Implementation :: CPython",
+]
+urls.homepage = "https://github.com/psychopy/psychopy-sounddevice"
+urls.changelog = "https://github.com/psychopy/psychopy-sounddevice/blob/main/CHANGELOG.txt"
+urls.documentation = "https://pages.github.com/psychopy/psychopy-sounddevice"
+urls.repository = "https://github.com/psychopy/psychopy-sounddevice"
+dependencies = [
+  "numpy",
+  "sounddevice",
+  "soundfile",
+]
+
+[tool.setuptools.packages.find]
+where = ["",]
+
+[project.entry-points."psychopy.sound"]
+backend_sounddevice = "psychopy_sounddevice.backend_sounddevice"

--- a/psychopy-sounddevice/setup.cfg
+++ b/psychopy-sounddevice/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+description-file=README.md
+license_files=LICENSE

--- a/psychopy-sounddevice/tests/test_multichannel_asio.py
+++ b/psychopy-sounddevice/tests/test_multichannel_asio.py
@@ -1,0 +1,33 @@
+#  in this test we're deliberately changing the sound lib in preferences which needs to be done before importing sound
+#  (otherwise the sound will be imported thinking it's a different preferred lib)
+from psychopy import prefs
+prefs.general['audioLib'] = ['sounddevice'] # noqa
+from psychopy import sound
+import numpy as np
+from psychopy import core  # import some libraries from PsychoPy
+
+# in case setting prefs wasn't sufficient (due to sound being imported already?)
+sound.Sound = sound.backend_sounddevice.SoundDeviceSound
+sound.backend = sound.backend_sounddevice
+
+fs = 44100
+my_asio_device = 'ASIO Fireface USB'
+
+all_devices = sound.backend.sd.query_devices()
+device_found = np.any([_d['name'] == my_asio_device for _d in all_devices])
+if not device_found:
+    print('device {:} not found'.format(my_asio_device))
+else:
+    sound.backend.sd.default.device = my_asio_device
+    sound.setDevice(my_asio_device)
+    sound_device_channels = [1, 4, 5, 6]
+    sound.backend.sd.default.device = 'ASIO Fireface USB'
+    sound.backend.sd.mapping = None
+    extra_settings = sound.backend.sd.AsioSettings(channel_selectors=sound_device_channels)
+    sound.backend.sd.default.extra_settings = extra_settings
+    y = np.sin(2 * np.pi * 500 * np.arange(0, 1, 1 / fs))
+    y = np.vstack((y, y, y, y))
+    a = sound.Sound(value=y.T, sampleRate=fs)
+    a.play()
+    core.wait(4.0)
+    core.quit()

--- a/psychopy-sounddevice/tests/test_sound_sounddevice.py
+++ b/psychopy-sounddevice/tests/test_sound_sounddevice.py
@@ -1,0 +1,81 @@
+"""Test PsychoPy sound.py using pyo backend
+"""
+import pytest
+import shutil, os
+from tempfile import mkdtemp
+import numpy as np
+
+from psychopy import prefs, core
+from psychopy.tests import utils
+from psychopy import sound
+
+from importlib import reload
+
+origSoundPref = prefs.hardware['audioLib']
+
+# py.test --cov-report term-missing --cov sound.py tests/test_sound/test_sound_pyo.py
+
+
+@pytest.mark.needs_sound
+class TestSoundDevice():
+    @classmethod
+    def setup_class(self):
+        self.contextName='sounddevice'
+        prefs.hardware['audioLib'] = ['sounddevice']
+        reload(sound)
+        self.tmp = mkdtemp(prefix='psychopy-tests-sound')
+
+        self.testFile = os.path.join(utils.TESTS_DATA_PATH,
+                                     'Electronic_Chime-KevanGC-495939803.wav')
+
+    @classmethod
+    def teardown_class(self):
+        prefs.hardware['audioLib'] = origSoundPref
+        if hasattr(self, 'tmp'):
+            shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_init(self):
+        for note in ['A', 440, '440', [1,2,3,4], np.array([1,2,3,4])]:
+            sound.Sound(note, secs=.1)
+        with pytest.raises(ValueError):
+            sound.Sound('this is not a file name')
+        with pytest.raises(ValueError):
+            sound.Sound(-1)  # negative frequency makes no sense
+
+        points = 100
+        snd = np.ones(points) / 20  # noqa
+
+        s = sound.Sound(self.testFile)  # noqa
+
+    def test_play(self):
+        s = sound.Sound(secs=0.1)
+        s.play()
+        core.wait(s.getDuration()+.1)
+        s.play(loops=1)  # exactly one loop
+        core.wait(s.getDuration()*2+.1)  # allows coverage of _onEOS
+        s.play(loops=-1)  # infinite loops
+        s.stop()
+
+    def test_start_stop(self):
+        """only relevant for sound from files"""
+        s1 = sound.Sound(self.testFile, startTime=0.5, stopTime=1.5)
+        assert s1.getDuration() == 1
+        s2 = sound.Sound(self.testFile, startTime=0.5)
+        s3 = sound.Sound(self.testFile)
+        assert s3.getDuration() > s2.getDuration() > s1.getDuration()
+        s4 = sound.Sound(self.testFile, startTime=-1, stopTime=10000)
+        assert s4.getDuration() == s3.getDuration()
+
+    def test_methods(self):
+        s = sound.Sound(secs=0.1)
+        v = s.getVolume()
+        assert v == 1
+        s.setVolume(0.5)
+        assert s.getVolume() == 0.5
+        s.setLoops(2)
+        assert s.getLoops() == 2
+
+    def test_reinit_pyo(self):
+        pytest.skip()
+        # was stalling on some machines; revisit if decide to stick with pyo
+        sound.initPyo()

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,9 @@ click
 # a specific version prevents an endless dependency resolution loop.
 pyobjc==7.3; sys_platform == 'darwin'
 #upgrade psychopy to use newer wxpython dependency which is prebuilt for m1 support.
-psychopy==2023.2.2
+psychopy==2025.1.1
+#needed for macos arm sound support: https://github.com/psychopy/psychopy-sounddevice/pull/4
+-e psychopy-sounddevice
 ffpyplayer==4.5.2 # 4.5.3 fails to build as wheel.
 psychtoolbox
 scikit-learn>=0.23.2

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,25 @@ from setuptools import setup, find_packages
 with open("README.rst", "r") as fh:
     long_description = fh.read()
 
+def filter_requirements(requirements_list):
+    """Filter out invalid requirement specifiers"""
+    filtered = []
+    for req in requirements_list:
+        req = req.strip()
+        # Skip empty lines, comments, and editable installs
+        if req and not req.startswith('#') and not req.startswith('-e'):
+            # Remove inline comments
+            if '#' in req:
+                req = req.split('#')[0].strip()
+            if req:  # Make sure it's still not empty after removing inline comments
+                filtered.append(req)
+    return filtered
+
 fptxt = open('requirements.txt', 'r').read()
-install_requires_analysis = fptxt.split('## ~~ Analysis Requirements ~~')[1].split('## ~~')[0].splitlines()[1:]
-install_requires_streaming = fptxt.split('## ~~ Streaming Requirements ~~')[1].split('## ~~')[0].splitlines()[1:]
-install_requires_stimpres = fptxt.split('## ~~ Stimpres Requirements ~~')[1].split('## ~~')[0].splitlines()[1:]
-install_requires_docsbuild = fptxt.split('## ~~ Docsbuild Requirements ~~')[1].split('## ~~')[0].splitlines()[1:]
+install_requires_analysis = filter_requirements(fptxt.split('## ~~ Analysis Requirements ~~')[1].split('## ~~')[0].splitlines()[1:])
+install_requires_streaming = filter_requirements(fptxt.split('## ~~ Streaming Requirements ~~')[1].split('## ~~')[0].splitlines()[1:])
+install_requires_stimpres = filter_requirements(fptxt.split('## ~~ Stimpres Requirements ~~')[1].split('## ~~')[0].splitlines()[1:])
+install_requires_docsbuild = filter_requirements(fptxt.split('## ~~ Docsbuild Requirements ~~')[1].split('## ~~')[0].splitlines()[1:])
 
 setup(
     name="eeg-expy", 
@@ -20,7 +34,7 @@ setup(
     keywords='eeg, cognitive neuroscience, experiments, evoked response, auditory, visual',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=[ install_requires_analysis ],   # base dependencies
+    install_requires=install_requires_analysis,   # base dependencies
     extras_require={
         'docsbuild':  install_requires_docsbuild,
         'streaming':  install_requires_streaming,

--- a/tests/test_run_experiments.py
+++ b/tests/test_run_experiments.py
@@ -62,8 +62,8 @@ test_config = dict(run_n170 = True,
                    )
 # -----------------------------------------------------------------------
 # ***EDIT THIS SECTION ONLY*** to specify any non-default config entries
-test_config['audio_device'] = "Speakers (Apple Audio Device)"  # see `sound.getDevices()` 
-test_config['audio_lib'] = "ptb"
+test_config['audio_device'] = 'MacBook Pro Speakers' # see `sound.getDevices()`
+test_config['audio_lib'] = 'sounddevice'
 # ----------------------------------------------------------------------
 
 # ---------------------------------------
@@ -75,9 +75,17 @@ test_config['audio_lib'] = "ptb"
 #
 # ---------------------------------------
 
+# ---------------------------------------
+# CONFIG NOTES:
+#
+# - macOS 15.5 on Macbook Pro M1 (through bootcamp):
+#     test_config['audio_device'] = 'MacBook Pro Speakers'
+#     test_config['audio_lib'] = 'sounddevice'
+#
+# ---------------------------------------
+
 tc = test_config
 
-assert tc['audio_device'] in sound.getDevices()
 d = tc['test_duration']
 
 
@@ -100,9 +108,14 @@ if tc['run_ssvep']:
     expt.run()
 
 if tc['run_aob']:
-    from eegnb.experiments.auditory_oddball.aob import AuditoryOddball
+    # prefs need to be set before importing eegnb.experiments, otherwise the default audio device will be used for the 'sounddevice' lib.
     prefs.hardware['audioDevice'] = tc['audio_device']
     prefs.hardware['audioLib'] = tc['audio_lib']
+    from eegnb.experiments.auditory_oddball.aob import AuditoryOddball
+
+    # sound.getDevices() will fail for sounddevice lib until eegnb.experiments is imported.
+    assert tc['audio_device'] in sound.getDevices()
+
     expt = AuditoryOddball(duration=d)
     expt.use_fullscr = tc['fullscreen']
     expt.run()


### PR DESCRIPTION
* Updated Psychopy version to 2025.1.1 and added `cffi` dependency in conda environments to fix MacOS ARM sound issues.
* Removed Psychopy PTB audio preferences and updated sound configuration for compatibility with macOS ARM and sounddevice backend.
* Use forked version of `psychopy-soundevice` until patches are merged into official repo.