### PR TITLE
Add pyxid2 device for nirx fnirs recording triggers

### DIFF
--- a/eegnb/devices/utils.py
+++ b/eegnb/devices/utils.py
@@ -29,6 +29,7 @@ EEG_CHANNELS = {
     "freeeeg32": [f"eeg_{i}" for i in range(0, 32)],
     "kernelflow": [],
     "biosemi": [],
+    "nirsport2": [],
 }
 
 BRAINFLOW_CHANNELS = {
@@ -60,6 +61,7 @@ EEG_INDICES = {
     "freeeeg32": BoardShim.get_eeg_channels(BoardIds.FREEEEG32_BOARD.value),
     "kernelflow": [],
     "biosemi": [],
+    "nirsport2": [],
     }
 
 SAMPLE_FREQS = {
@@ -84,6 +86,7 @@ SAMPLE_FREQS = {
     "freeeeg32": BoardShim.get_sampling_rate(BoardIds.FREEEEG32_BOARD.value),
     "kernelflow": [],
     "biosemi": [],
+    "nirsport2": [],
     }
 
 


### PR DESCRIPTION
This PR creates another minimal device type, exactly the same concept and general structure as the `serial` device type. That is, its only purpose is to push triggers, and does not (unlike e.g. the brainflow devices) also have the more important task of controlling a streamed data recording. 

This code was written and added out of necessity, as the `pyxid2` library appears to be the only way to send triggers to the `NIRX nirsport2` via a USB cable. The serial device type does not work for this. 


Example usage:

```python  
from eegnb.devices.eeg import EEG  as eegexpy_device
thisdev = eegexpy_device(device="nirsport2", xid_num=1)  
thisdev.push_sample(marker=2, timestamp=0) # note that timestamp is not currently used
                                                                           # in this context
# for the nirx nirsport2 the above can be viewed and checked at the bottom of the aurora 
# recording software

# ( in full context: )
from eegnb.experiments.visual_n170.n170 import VisualN170  
thisdev = eegexpy_device(device="nirsport2", xid_num=1)  
thisexp = VisualN170(eeg=thisdev, duration=300, use_fullscr=False, screen_num=1)  
thisexp.run()  

```
