### PR TITLE
Add multidevice

### DIFF
--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -27,7 +27,7 @@ from eegnb import generate_save_fn
 class BaseExperiment(ABC):
 
     def __init__(self, exp_name, duration, eeg, save_fn, n_trials: int, iti: float, soa: float, jitter: float,
-                 use_vr=False, use_fullscr = True, screen_num=0, stereoscopic = False):
+                 use_vr=False, use_fullscr = True, screen_num=0, stereoscopic = False, devices = list):
         """ Initializer for the Base Experiment Class
 
         Args:
@@ -50,6 +50,7 @@ class BaseExperiment(ABC):
         Press spacebar to continue. \n""".format(self.exp_name)
         self.duration = duration
         self.eeg: EEG = eeg
+        self.devices = devices
         self.save_fn = save_fn
         self.n_trials = n_trials
         self.iti = iti
@@ -344,7 +345,7 @@ class BaseExperiment(ABC):
     def send_triggers(self, marker):
         """Send timing triggers to recording device[s]"""
         for dev in self.devices:
-            timestmamp = time()
+            timestamp = time()
             dev.push_sample(marker=marker, timestamp=timestamp)
 
 

--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -339,6 +339,15 @@ class BaseExperiment(ABC):
         # Closing the window
         self.window.close()
 
+
+
+    def send_triggers(self, marker):
+        """Send timing triggers to recording device[s]"""
+        for dev in self.devices:
+            timestmamp = time()
+            dev.push_sample(marker=marker, timestamp=timestamp)
+
+
     @property
     def name(self) -> str:
         """ This experiment's name """

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -15,14 +15,13 @@ from typing import Optional
 
 class VisualN170(Experiment.BaseExperiment):
 
-    def __init__(self, duration=120, eeg: Optional[EEG]=None, save_fn=None,
-
+    def __init__(self, duration=120, eeg: Optional[EEG]=None, devices: Optional[list]=None,save_fn=None,
             n_trials = 2010, iti = 0.4, soa = 0.3, jitter = 0.2, use_vr = False):
 
         # Set experiment name        
         exp_name = "Visual N170"
         # Calling the super class constructor to initialize the experiment variables
-        super(VisualN170, self).__init__(exp_name, duration, eeg, save_fn, n_trials, iti, soa, jitter, use_vr)
+        super(VisualN170, self).__init__(exp_name, duration, eeg, save_fn, n_trials, iti, soa, jitter, use_vr, devices=devices)
 
     def load_stimulus(self):
         

--- a/eegnb/experiments/visual_n170/n170.py
+++ b/eegnb/experiments/visual_n170/n170.py
@@ -45,13 +45,24 @@ class VisualN170(Experiment.BaseExperiment):
         # Draw the image
         image.draw()
 
+
         # Pushing the sample to the EEG
         if self.eeg:
             timestamp = time()
+
             if self.eeg.backend == "muselsl":
                 marker = [self.markernames[label]]
             else:
                 marker = self.markernames[label]
+            
             self.eeg.push_sample(marker=marker, timestamp=timestamp)
-        
+      
+
+        if self.devices:
+            marker = self.markernames[label]
+            self.send_triggers(marker)
+
+
         self.window.flip()
+
+


### PR DESCRIPTION

initial implementation of multi-device configuration

a 'devices' argument has been added to the Experiment class

this will consist of a list of devices, whereas the current setup is to hand a single device to the `eeg` argument

behaviour is otherwise identical as to when the single eeg device is handled, but it iterates through the list

the expectation is that in the medium term, this will become the default usage, and the single-device option will be gracefully deprecated

however because this is a major change, this will be done gradually to be sure of no breakages

active testing is currently with the serial and pyxid2 ports (for concurrent biosemi and nirsport recordings); but this should eventually be easily used with, for example, two brainflow devices (eg a muse and a neurosity both worn on the head at the same time), or alternatively eg a muse and a serial device for trigger testing

