### PR TITLE
Drop pynput dependency to fix Linux installs

### DIFF
--- a/eegnb/analysis/streaming_utils.py
+++ b/eegnb/analysis/streaming_utils.py
@@ -7,8 +7,9 @@ from collections import OrderedDict
 from glob import glob
 from typing import Union, List
 from time import sleep, time
-from pynput import keyboard
 import os
+
+from eegnb.utils.cancel import wait_for_cancel
 
 import pandas as pd
 import numpy as np
@@ -192,21 +193,10 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=None, th
         if (loop_index+1) % n_inarow == 0:
             print(f"\n\nLooks like you still have {len(bad_channels)} bad channels after {loop_index+1} tries\n")
 
-            prompt_time = time()
-            print(f"Starting next cycle in 5 seconds, press C and enter to cancel")
-            c_key_pressed = False
-
-            def update_key_press(key):
-                if key.char == 'c':
-                    globals().update(c_key_pressed=True)
-            listener = keyboard.Listener(on_press=update_key_press)
-            listener.start()
-            while time() < prompt_time + 5:
-                if c_key_pressed:
-                    print("\nStopping signal quality checks!")
-                    flag = True
-                    break
-            listener.stop()
+            print("Starting next cycle in 5 seconds, press C and enter to cancel")
+            if wait_for_cancel(timeout=5.0, cancel_key="c"):
+                print("\nStopping signal quality checks!")
+                flag = True
         if flag: 
             break  
 

--- a/eegnb/analysis/utils.py
+++ b/eegnb/analysis/utils.py
@@ -25,7 +25,7 @@ from scipy.signal import lfilter, lfilter_zi
 from eegnb import _get_recording_dir
 from eegnb.devices.eeg import EEG
 from eegnb.devices.utils import EEG_INDICES, SAMPLE_FREQS
-from pynput import keyboard
+from eegnb.utils.cancel import wait_for_cancel
 
 # this should probably not be done here
 sns.set_context("talk")
@@ -529,21 +529,10 @@ def check_report(eeg: EEG, n_times: int=60, pause_time=5, thres_std_low=None, th
         if (loop_index+1) % n_inarow == 0:
             print(f"\n\nLooks like you still have {len(bad_channels)} bad channels after {loop_index+1} tries\n")
 
-            prompt_time = time()
-            print(f"Starting next cycle in 5 seconds, press C and enter to cancel")
-            c_key_pressed = False
-
-            def update_key_press(key):
-                if key.char == 'c':
-                    globals().update(c_key_pressed=True)
-            listener = keyboard.Listener(on_press=update_key_press)
-            listener.start()
-            while time() < prompt_time + 5:  
-                if c_key_pressed:
-                    print("\nStopping signal quality checks!")
-                    flag = True
-                    break
-            listener.stop()
+            print("Starting next cycle in 5 seconds, press C and enter to cancel")
+            if wait_for_cancel(timeout=5.0, cancel_key="c"):
+                print("\nStopping signal quality checks!")
+                flag = True
         if flag: 
             break
             

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -20,7 +20,13 @@ from pylsl import StreamInfo, StreamOutlet, StreamInlet, resolve_byprop
 
 from serial import Serial, EIGHTBITS, PARITY_NONE, STOPBITS_ONE
 
-import pyxid2
+# pyxid2 is only needed for Cedrus XID response boxes (nirsport2 here).
+# It has C-build issues on some platforms and is not required by the
+# common Muse / OpenBCI / Unicorn paths, so make it optional.
+try:
+    import pyxid2
+except ImportError:
+    pyxid2 = None
 
 from eegnb.devices.utils import (
     get_openbci_usb,
@@ -621,6 +627,11 @@ class EEG:
 
 
     def _init_xid(self):
+        if pyxid2 is None:
+            raise ImportError(
+                "pyxid2 is required for Cedrus XID response boxes. "
+                "Install with: pip install pyxid2"
+            )
         if self.xid_num is not None:      # if an xis device number is supplied, open and init that device
             xids_list = pyxid2.get_xid_devices()
             xid = xids_list[self.xid_num]

--- a/eegnb/utils/cancel.py
+++ b/eegnb/utils/cancel.py
@@ -1,0 +1,38 @@
+"""Cross-platform stdin-based cancel prompt.
+
+Replaces ``pynput.keyboard.Listener`` for the simple case of "give the
+user N seconds to press a key + Enter to cancel an operation". Uses a
+daemon thread reading from stdin so it works on Linux / macOS / Windows
+and in terminals without a ``DISPLAY``.
+
+pynput was dropped because it pulls in evdev (Linux) which currently
+fails to build from source under several common toolchains.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+
+
+def wait_for_cancel(timeout: float, cancel_key: str = "c") -> bool:
+    """Block for up to ``timeout`` seconds waiting for the user to type
+    ``cancel_key`` + Enter on stdin.
+
+    Returns True if cancel was requested, False if the timeout elapsed.
+    """
+    cancel_event = threading.Event()
+    cancel_key = cancel_key.strip().lower()
+
+    def _reader() -> None:
+        try:
+            line = sys.stdin.readline()
+        except (OSError, ValueError):
+            return
+        if line and line.strip().lower() == cancel_key:
+            cancel_event.set()
+
+    thread = threading.Thread(target=_reader, daemon=True)
+    thread.start()
+    cancel_event.wait(timeout=timeout)
+    return cancel_event.is_set()

--- a/eegnb/utils/cancel.py
+++ b/eegnb/utils/cancel.py
@@ -3,7 +3,7 @@
 Replaces ``pynput.keyboard.Listener`` for the simple case of "give the
 user N seconds to press a key + Enter to cancel an operation". Uses a
 daemon thread reading from stdin so it works on Linux / macOS / Windows
-and in terminals without a ``DISPLAY``.
+and in terminals without a ``DISPLAY`` (e.g. headless rigs over SSH, or CI).
 
 pynput was dropped because it pulls in evdev (Linux) which currently
 fails to build from source under several common toolchains.
@@ -11,8 +11,33 @@ fails to build from source under several common toolchains.
 
 from __future__ import annotations
 
+import queue
 import sys
 import threading
+import time
+
+# stdin.readline() has no timeout, so one daemon thread reads lines into this
+# queue and each prompt waits on the queue with its own deadline.
+_lines: queue.Queue[str] = queue.Queue()
+_reader_started = threading.Event()
+
+
+def _ensure_reader() -> None:
+    if _reader_started.is_set():
+        return
+    _reader_started.set()
+
+    def _pump() -> None:
+        while True:
+            try:
+                line = sys.stdin.readline()
+            except (OSError, ValueError):
+                return
+            if line == "":  # EOF
+                return
+            _lines.put(line)
+
+    threading.Thread(target=_pump, name="eegnb-stdin-cancel", daemon=True).start()
 
 
 def wait_for_cancel(timeout: float, cancel_key: str = "c") -> bool:
@@ -21,18 +46,24 @@ def wait_for_cancel(timeout: float, cancel_key: str = "c") -> bool:
 
     Returns True if cancel was requested, False if the timeout elapsed.
     """
-    cancel_event = threading.Event()
-    cancel_key = cancel_key.strip().lower()
+    _ensure_reader()
+    key = cancel_key.strip().lower()
 
-    def _reader() -> None:
+    # discard input typed before this prompt
+    while True:
         try:
-            line = sys.stdin.readline()
-        except (OSError, ValueError):
-            return
-        if line and line.strip().lower() == cancel_key:
-            cancel_event.set()
+            _lines.get_nowait()
+        except queue.Empty:
+            break
 
-    thread = threading.Thread(target=_reader, daemon=True)
-    thread.start()
-    cancel_event.wait(timeout=timeout)
-    return cancel_event.is_set()
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        try:
+            line = _lines.get(timeout=remaining)
+        except queue.Empty:
+            return False
+        if line.strip().lower() == key:
+            return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,8 +39,11 @@ pyo>=1.0.3; platform_system == "Linux"
 #pynput requires pyobjc, psychopy requires a version less than 8, setting pyobjc to
 # a specific version prevents an endless dependency resolution loop.
 pyobjc==7.3; sys_platform == 'darwin'
-#Removed keyboard dependency due segmentation fault on Apple Silicon: https://github.com/boppreh/keyboard/issues/507
-pynput
+#Removed pynput dependency: it pulls in evdev, which fails to build from
+#source on modern Linux under the conda toolchain (missing kernel header
+#symbols). The two callsites that used pynput.keyboard.Listener have been
+#replaced with a threading + stdin "press enter to cancel" helper in
+#eegnb/utils/cancel.py — cross-platform, zero new deps.
 airium>=0.1.0
 attrdict>=2.0.1
 attrdict3

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,11 @@ pyserial>=3.5
 h5py>=3.1.0
 pytest-shutil
 pyobjc>=8.0; sys_platform == 'darwin'
-#Removed keyboard dependency due segmentation fault on Apple Silicon: https://github.com/boppreh/keyboard/issues/507
-pynput
+#Removed pynput dependency: it pulls in evdev, which fails to build from
+#source on modern Linux under the conda toolchain (missing kernel header
+#symbols). The two callsites that used pynput.keyboard.Listener have been
+#replaced with a threading + stdin "press enter to cancel" helper in
+#eegnb/utils/cancel.py — cross-platform, zero new deps.
 airium>=0.1.0
 attrdict>=2.0.1
 attrdict3


### PR DESCRIPTION
## Summary

- `pynput` pulls in `evdev`, which fails to build on many modern Linux toolchains (missing `SND_PROFILE_RING` symbol when the build environment's kernel headers or conda sysroot is older than the one `evdev` 1.9 expects). Users hitting this see a wall of C compile errors at install time, and `pip install eeg-notebooks` becomes non-functional on Fedora 43 + miniconda, and on several fresh-install Ubuntu/Debian setups.
- `pynput` is only used in two places: the \"press C + enter within 5s to cancel\" prompt inside `check_report` in `analysis/utils.py` and its twin in `analysis/streaming_utils.py`. Neither benefits from pynput's global-keyboard hook — a plain stdin read suffices.

This PR replaces both callsites with a small `wait_for_cancel(timeout, cancel_key)` helper (`eegnb/utils/cancel.py`, ~40 lines) that reads stdin on a daemon thread. Cross-platform, zero new dependencies, identical observable UX.

It also makes the top-level `import pyxid2` in `devices/eeg.py` lazy: `pyxid2` is only exercised by the Cedrus XID response-box path (`_init_xid`), and is not needed for Muse / OpenBCI / Unicorn. Wrapping the import in try/except unblocks environments where the Cedrus C library isn't installable while still raising a clear `ImportError` if the user actually invokes `_init_xid` without it.

No behaviour change on the supported backends.

## Test plan

- [x] \`pip install -e .[streamstim]\` now succeeds on Fedora 43 + Python 3.11 where it previously errored on the evdev build.
- [x] \`python -c \"from eegnb.analysis.utils import check_report\"\` imports without pynput installed.
- [x] \`python -c \"from eegnb.devices.eeg import EEG\"\` imports without pyxid2 installed.
- [x] The cancel prompt still cancels the signal-quality loop when the user types \`c\` + enter within 5s; still times out silently otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)